### PR TITLE
Fix assembly copying

### DIFF
--- a/Editor/Core/Data/ThunderKitSettings.cs
+++ b/Editor/Core/Data/ThunderKitSettings.cs
@@ -27,20 +27,23 @@ namespace ThunderKit.Core.Data
         [InitializeOnLoadMethod]
         static void SetupPostCompilationAssemblyCopy()
         {
-            CompilationPipeline.assemblyCompilationFinished -= LoadAllAssemblies;
-            CompilationPipeline.assemblyCompilationFinished += LoadAllAssemblies;
-            LoadAllAssemblies(null, null);
+            EditorApplication.quitting -= EditorApplicationQuitting;
+            EditorApplication.quitting += EditorApplicationQuitting;
+
+            CompilationPipeline.assemblyCompilationFinished -= CopyAssemblyCSharp;
+            CompilationPipeline.assemblyCompilationFinished += CopyAssemblyCSharp;
+
             GetOrCreateSettings<ThunderKitSettings>();
         }
 
-
-        private static readonly string[] CopyFilePatterns = new[] { "*.dll", "*.mdb", "*.pdb" };
-        static void LoadAllAssemblies(string somevalue, CompilerMessage[] message)
+        private static void EditorApplicationQuitting()
         {
-            var targetFiles = from pattern in CopyFilePatterns
-                              from file in Directory.GetFiles("Packages", pattern, SearchOption.AllDirectories)
-                              select file;
-            foreach (var file in targetFiles)
+            CopyAssemblyCSharp(null, null);
+        }
+
+        static void CopyAssemblyCSharp(string somevalue, CompilerMessage[] message)
+        {
+            foreach (var file in Directory.GetFiles("Packages", "Assembly-CSharp.dll", SearchOption.AllDirectories))
             {
                 var fileName = Path.GetFileName(file);
                 var outputPath = Combine("Library", "ScriptAssemblies", fileName);


### PR DESCRIPTION
The main issue is that when you quit Unity without recompiling any assembly there will be no `Assembly-CSharp.dll` in `Library\ScriptAssemblies` thus you will have missing scripts until you recompile something.

You don't need to copy all assemblies from `Packages` to `Library\ScriptAssemblies` because Unity can load them just fine where they are, with exception of `Assembly-CSharp.dll`.

Calling `LoadAllAssemblies()` without an event wasn't doing anything, because methods with an `InitializeOnLoadMethod` attribute are called after all assemblies are loaded into AppDomain, so it was too late to replace anything.

We had a discussion about it here: https://discord.com/channels/562704639141740588/562704639569428506/930129511167696896.
After loading a project Unity cleans up `Library\ScriptAssemblies` from everything that's not supposed to be there, including `Assembly-CSharp.dll`. It also happens after methods with an `InitializeOnLoadMethod` attribute are called, so `LoadAllAssemblies` wasn't doing anything to fix that issue.

I copy `Assembly-CSharp.dll` when you are closing a project, so even if you quit without any dll being recompiled, you will have `Assembly-CSharp.dll` when you open that project next time.