### PR TITLE
FlowPipelineJob BlackList/WhiteList

### DIFF
--- a/Editor/Core/Pipelines/FlowPipelineJob.cs
+++ b/Editor/Core/Pipelines/FlowPipelineJob.cs
@@ -1,12 +1,17 @@
 using System.Linq;
 using System.Threading.Tasks;
+using UnityEngine.Serialization;
 
 namespace ThunderKit.Core.Pipelines
 {
     public abstract class FlowPipelineJob : PipelineJob
     {
+        public enum ManifestListType { BlackList, WhiteList }
+
         public bool PerManifest;
-        public Manifests.Manifest[] ExcludedManifests;
+        public ManifestListType ListType;
+        [FormerlySerializedAs("ExcludedManifests")]
+        public Manifests.Manifest[] Manifests;
 
         public sealed override async Task Execute(Pipeline pipeline)
         {
@@ -16,7 +21,15 @@ namespace ThunderKit.Core.Pipelines
                      pipeline.ManifestIndex < pipeline.Manifests.Length;
                      pipeline.ManifestIndex++)
                 {
-                    if (ExcludedManifests.Contains(pipeline.Manifest)) continue;
+                    switch (ListType)
+                    {
+                        case ManifestListType.BlackList:
+                            if (Manifests.Contains(pipeline.Manifest)) continue;
+                            break;
+                        case ManifestListType.WhiteList:
+                            if (!Manifests.Contains(pipeline.Manifest)) continue;
+                            break;
+                    }
 
                     await ExecuteInternal(pipeline);
                 }


### PR DESCRIPTION
Sometimes you want to execute a job only for a specific manifests, in my case it was Zip job for publishing pipeline.
Because `FormerlySerializedAs` is used, already existing pipelines will work as before, excluding manifests in the list.