### PR TITLE
Documentation Fixes and Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.0
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc in felis ac enim facilisis laoreet. Donec viverra augue at ipsum ultrices, non viverra eros vestibulum. Nam scelerisque, est ac pretium pretium, nunc elit blandit neque, et tincidunt dolor neque sed neque. Suspendisse condimentum augue nisl, non placerat purus aliquet sed. Cras tristique posuere ullamcorper. Morbi elementum orci quam, eu ullamcorper lectus sagittis sit amet. Aliquam at lorem sit amet mi gravida dignissim. Etiam vitae dui in elit ornare auctor. Sed nisl erat, semper eget luctus quis, ullamcorper ac diam. Nam finibus quam tellus, a mollis nisl cursus ut. Nunc hendrerit malesuada euismod. Aliquam eu libero efficitur, volutpat tortor quis, vehicula tortor.
+
 ## 4.1.1
 
 ### Pipelines and Logging

--- a/Documentation/ThunderKitDocumentation/1st Read Me!.md
+++ b/Documentation/ThunderKitDocumentation/1st Read Me!.md
@@ -25,6 +25,8 @@ your inspector. Open the [Project window](menulink://Window/General/Project) and
 
 - [Internet Hyperlinks](http://) are links to websites such as the [Unity Manual](https://docs.unity3d.com/Manual/index.html) or [ThunderKit Git Repository](https://github.com/PassivePicasso/ThunderKit) and will launch in your default Web Browser.
 
+- [Documentation Links](documentation://) use the `documentation://` scheme and are shortcuts to Documentation pages. These can be used to quickly browse between relevant topics, such as a manifest datum and it's respective pipeline job.
+
 This page will be updated as more types of links are added.
 
 MarkdownElement's links do not track visitation, so the color of links will not change from usage.

--- a/Documentation/ThunderKitDocumentation/1st Read Me!.md
+++ b/Documentation/ThunderKitDocumentation/1st Read Me!.md
@@ -40,9 +40,9 @@ However, you can select and copy from code blocks like this one
 
 ThunderKit Documentation is built on a [UIToolkit](https://docs.unity3d.com/2018.4/Documentation/Manual/UIElements.html) Markdown system.
 
-See the [Documentation Folder](assetlink://Packages/com.passivepicasso.thunderkit/Documentation) for the Markdown files that makes up this documentation.
+See the [Documentation Folder](assetlink://GUID/8a4cd14903a156d48ac381bd86e23e48) for the Markdown files that makes up this documentation.
 
-ThunderKit's [MarkdownElement](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Markdown/MarkdownElement.cs) renders Markdown using  
-[Markdig 18.3](assetlink://Packages/com.passivepicasso.thunderkit/Editor/ThirdParty/MarkDig/license.txt) 
+ThunderKit's [MarkdownElement](assetlink://GUID/ec19b76b765719a4fb4383a4fa9324ea) renders Markdown using  
+[Markdig 18.3](assetlink://GUID/a3cea14f6fefce94082492a3e8df5358) 
 
 Go to the [Markdig GitHub Repository](https://github.com/xoofx/markdig) for more information about Markdig.

--- a/Documentation/ThunderKitDocumentation/Reference/ComposableObject.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ComposableObject.md
@@ -16,3 +16,9 @@ a existing and new ComposableObjects when a script template is specified.
 Manifests, Pipelines, and PathReferences are built upon ComposableObject so that they can benefit from this common feature set, and to allow users to add new functionality as needed. The Add Script window will allow you to create new components for each of these systems.
 
 Continue reading below to gain an understanding of the existing systems ThunderKit uses to help you develop, test, and deploy your mods.
+
+[Manifest Documentation](documentation://GUID/02282fc15986c8941b791e56e592db1f)
+
+[Pipeline Documentation](documentation://GUID/3cc273aff4638a242a847ff6c94a0521)
+
+[Path Documentation](documentation://GUID/38dcf73e153c4aa4ab413bcd9c568be8)

--- a/Documentation/ThunderKitDocumentation/Reference/Manifest.md
+++ b/Documentation/ThunderKitDocumentation/Reference/Manifest.md
@@ -16,4 +16,4 @@ All Manifests are prepopulated with a ManifestIdentity. The ManifestIdentity is 
 
 ManifestDatums all have an array named Staging Paths.  This array of strings informs Pipelines where the information is expected to be written out to. As previously mentioned, the StagingPaths array can utilize PathReferences by invoking one with the arrow bracket operators <>.
 
-If you would like to check out an example, inspect the [Default-BepInEx](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Templates/BepInEx/Manifests/Default-BepInEx.asset) manifest in the ThunderKit Package.
+If you would like to check out an example, inspect the [Default-BepInEx](assetlink://GUID/bc5e6d3336544e5361d16e63ddfca327) manifest in the ThunderKit Package.

--- a/Documentation/ThunderKitDocumentation/Reference/Manifest.md
+++ b/Documentation/ThunderKitDocumentation/Reference/Manifest.md
@@ -10,7 +10,7 @@
 
 # Manifest {#manifest .page-header-container .header-icon-manifest }
 
-Manifests are where you will store all the information about your projects for ThunderKit to utilize. This includes meta data information for mod distribution systems like Thunderstore. Manifests are composed of ManifestDatums there are many ManifestDatums already available. Check the ManifestDatums section for a list of ManifestDatums and their functionality.
+Manifests are where you will store all the information about your projects for ThunderKit to utilize. This includes meta data information for mod distribution systems like Thunderstore. Manifests are composed of ManifestDatums, there are many ManifestDatums already available. Check the ManifestDatums section for a list of ManifestDatums and their functionality.
 
 All Manifests are prepopulated with a ManifestIdentity. The ManifestIdentity is where information about the identity of a mod and what dependencies it has are stored.  You can drag and drop any Manifest into the ManifestIdentity's Dependencies field, or access it from the Unity asset finder by clicking the small circle.
 

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums.md
@@ -16,9 +16,9 @@ ManifestDatums and PipelineJobs are paired together in ThunderKit.  When you cre
 
 Some pairs that already exist are;
 
-1. ManifestDatum [AssemblyDefinitions](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/AssemblyDefinitions.cs) and PipelineJob [StageAssemblies](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageAssemblies.cs)
-2. ManifestDatum [AssetBundleDefinitions](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/AssetBundleDefinitions.cs) and PipelineJob [StageAssetBundles](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageAssetBundles.cs)
-3. ManifestDatum [UnityPackages](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/UnityPackages.cs) and PipelineJob [StageUnityPackages](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageUnityPackages.cs)
+1. ManifestDatum [AssemblyDefinitions](assetlink://GUID/2b7e13dda513544419a89926bd12ad8a) and PipelineJob [StageAssemblies](assetlink://GUID/b5b20fac9c71fd64183cb7a8f359d73a)
+2. ManifestDatum [AssetBundleDefinitions](assetlink://GUID/17d1008b78cb6e846889b7778282fbef) and PipelineJob [StageAssetBundles](assetlink://GUID/924ee63e6c016f14d8a1560b288f15a3)
+3. ManifestDatum [UnityPackages](assetlink://GUID/dda4ac7962f04724eacfeb26af5e2b75) and PipelineJob [StageUnityPackages](assetlink://GUID/d087870ea8abaed4ca4c717444be0165)
 
 Examine these pairs of types to gain a better understanding of how to build your own customized set of data.
 

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums.md
@@ -16,9 +16,9 @@ ManifestDatums and PipelineJobs are paired together in ThunderKit.  When you cre
 
 Some pairs that already exist are;
 
-1. ManifestDatum [AssemblyDefinitions](assetlink://GUID/2b7e13dda513544419a89926bd12ad8a) and PipelineJob [StageAssemblies](assetlink://GUID/b5b20fac9c71fd64183cb7a8f359d73a)
-2. ManifestDatum [AssetBundleDefinitions](assetlink://GUID/17d1008b78cb6e846889b7778282fbef) and PipelineJob [StageAssetBundles](assetlink://GUID/924ee63e6c016f14d8a1560b288f15a3)
-3. ManifestDatum [UnityPackages](assetlink://GUID/dda4ac7962f04724eacfeb26af5e2b75) and PipelineJob [StageUnityPackages](assetlink://GUID/d087870ea8abaed4ca4c717444be0165)
+1. ManifestDatum [AssemblyDefinitions](documentation://GUID/cef5acb6a795c5d4d9031261ea82e891) and PipelineJob [StageAssemblies](documentation://GUID/c18be5deeb5af6d48b59ed26056ba2fc)
+2. ManifestDatum [AssetBundleDefinitions](documentation://GUID/b3d3f798ec15f8240ad5105c46ce59f5) and PipelineJob [StageAssetBundles](documentation://GUID/346cbbd3f6c582441908249cf4067307)
+3. ManifestDatum [UnityPackages](documentation://GUID/e3fa281f0f933e64480e9eecdf057350) and PipelineJob [StageUnityPackages](documentation://GUID/915bcab14ba398e48b20a17d5e79b13b)
 
 Examine these pairs of types to gain a better understanding of how to build your own customized set of data.
 

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/AssemblyDefinitions.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/AssemblyDefinitions.md
@@ -8,7 +8,7 @@
 
 ---
 
-The [AssemblyDefinitions](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/AssemblyDefinitions.cs) ManifestDatum stores references to Unity AssemblyDefinition objects.
+The [AssemblyDefinitions](assetlink://GUID/2b7e13dda513544419a89926bd12ad8a) ManifestDatum stores references to Unity AssemblyDefinition objects.
 
 ## Fields
 * **Definitions**
@@ -22,7 +22,7 @@ The [AssemblyDefinitions](assetlink://Packages/com.passivepicasso.thunderkit/Edi
 
 ## PipelineJobs
 
-* [StageAssemblies](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageAssemblies.cs) 
+* [StageAssemblies](assetlink://GUID/b5b20fac9c71fd64183cb7a8f359d73a) 
   - Copies each assembly referenced in each AssemblyDefinition ManifestDatum to the output paths defined in its Staging Paths.
 
 ## Remarks

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/AssemblyDefinitions.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/AssemblyDefinitions.md
@@ -22,7 +22,7 @@ The [AssemblyDefinitions](assetlink://GUID/2b7e13dda513544419a89926bd12ad8a) Man
 
 ## PipelineJobs
 
-* [StageAssemblies](assetlink://GUID/b5b20fac9c71fd64183cb7a8f359d73a) 
+* [StageAssemblies](documentation://GUID/c18be5deeb5af6d48b59ed26056ba2fc) 
   - Copies each assembly referenced in each AssemblyDefinition ManifestDatum to the output paths defined in its Staging Paths.
 
 ## Remarks

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/AssetBundleDefinitions.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/AssetBundleDefinitions.md
@@ -8,7 +8,7 @@
 
 ---
 
-[AssetBundleDefinitions](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/AssetBundleDefinitions.cs) allow you to specify what assets you would like to include in your project output in the form of Unity AssetBundle(s)
+[AssetBundleDefinitions](assetlink://GUID/17d1008b78cb6e846889b7778282fbef) allow you to specify what assets you would like to include in your project output in the form of Unity AssetBundle(s)
 
 ## Fields
 
@@ -24,7 +24,7 @@
 
 ## PipelineJobs
 
-* [StageAssetBundles](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageAssetBundles.cs) 
+* [StageAssetBundles](assetlink://GUID/924ee63e6c016f14d8a1560b288f15a3) 
   - Builds and deploys AssetBundles defined by AssetBundleDefinitions
 
 ## Remarks

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/AssetBundleDefinitions.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/AssetBundleDefinitions.md
@@ -24,7 +24,7 @@
 
 ## PipelineJobs
 
-* [StageAssetBundles](assetlink://GUID/924ee63e6c016f14d8a1560b288f15a3) 
+* [StageAssetBundles](documentation://GUID/346cbbd3f6c582441908249cf4067307) 
   - Builds and deploys AssetBundles defined by AssetBundleDefinitions
 
 ## Remarks

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/Files.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/Files.md
@@ -8,7 +8,7 @@
 
 ---
 
-The [AssemblyDefinitions](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/AssemblyDefinitions.cs) ManifestDatum stores references to Unity AssemblyDefinition objects.
+The [Files](assetlink://GUID/4b243ff405b33b94dbf5b6775dd9aa33) ManifestDatum stores references to assets inside your unity project.
 
 ## Fields
 * **Files**
@@ -22,9 +22,9 @@ The [AssemblyDefinitions](assetlink://Packages/com.passivepicasso.thunderkit/Edi
 
 ## PipelineJobs
 
-* [StageManifestFiles](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageManifestFiles.cs) 
+* [StageManifestFiles](assetlink://GUID/3570c76eb7a5c3c45942d9295a150917) 
   - Copies each asset referenced in each Files ManifestDatum to the output paths defined in its Staging Paths.
 
 ## Remarks
 
-Use this ManifestDatum to specify and group files to be deployed by Pipelines using the [StageManifestFiles](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageManifestFiles.cs) PipelineJob
+Use this ManifestDatum to specify and group files to be deployed by Pipelines using the [StageManifestFiles](assetlink://GUID/3570c76eb7a5c3c45942d9295a150917) PipelineJob

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/Files.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/Files.md
@@ -22,7 +22,7 @@ The [Files](assetlink://GUID/4b243ff405b33b94dbf5b6775dd9aa33) ManifestDatum sto
 
 ## PipelineJobs
 
-* [StageManifestFiles](assetlink://GUID/3570c76eb7a5c3c45942d9295a150917) 
+* [StageManifestFiles](documentation://GUID/0e4c94f5c80d49545b1a92238b82f66a) 
   - Copies each asset referenced in each Files ManifestDatum to the output paths defined in its Staging Paths.
 
 ## Remarks

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/ManifestIdentity.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/ManifestIdentity.md
@@ -32,10 +32,10 @@ The [ManifestIdentity](assetlink://GUID/f22bb7fd1d3b56a48bc52f8e407901d6) stores
   
 ## PipelineJobs
 
-* [StageDependencies](assetlink://GUID/1b4f4581088b47744a114c282abc085d)
+* [StageDependencies](documentation://GUID/af852fc5b31304e498e9def1c01db5c1)
   - Uses the ManifestIdentity.Dependencies array to deploy dependencies loaded by the ThunderKit Package Manager
 
-* [StageThunderstoreManifest](assetlink://GUID/dc52389347ae9634bbb7e74eba886518) 
+* [StageThunderstoreManifest](documentation://GUID/74a0394c4eaea384e89e7a3688053c2b) 
   - Uses ManifestIdentity information to construct a manifest json file for Thunderstore
 
 ## Remarks

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/ManifestIdentity.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/ManifestIdentity.md
@@ -8,7 +8,7 @@
 
 ---
 
-The [ManifestIdentity](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/ManifestIdentity.cs) stores unique identifying information used by ThunderKit to construct dependency information for package stores and mod loaders.
+The [ManifestIdentity](assetlink://GUID/f22bb7fd1d3b56a48bc52f8e407901d6) stores unique identifying information used by ThunderKit to construct dependency information for package stores and mod loaders.
 
 ### Fields
 * **Author**
@@ -32,10 +32,10 @@ The [ManifestIdentity](assetlink://Packages/com.passivepicasso.thunderkit/Editor
   
 ## PipelineJobs
 
-* [StageDependencies](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageDependencies.cs)
+* [StageDependencies](assetlink://GUID/1b4f4581088b47744a114c282abc085d)
   - Uses the ManifestIdentity.Dependencies array to deploy dependencies loaded by the ThunderKit Package Manager
 
-* [StageThunderstoreManifest](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageThunderstoreManifest.cs) 
+* [StageThunderstoreManifest](assetlink://GUID/dc52389347ae9634bbb7e74eba886518) 
   - Uses ManifestIdentity information to construct a manifest json file for Thunderstore
 
 ## Remarks

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/ThunderstoreData.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/ThunderstoreData.md
@@ -8,7 +8,7 @@
 
 ---
 
-The [ThunderstoreData](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Integrations/Thunderstore/ThunderstoreData.cs) ManifestDatum stores a URL and identifies the Manifest as being a Thunderstore compatible Manifest.
+The [ThunderstoreData](assetlink://GUID/e0a82fec78ebc734d9ad1346cd40b5f9) ManifestDatum stores a URL and identifies the Manifest as being a Thunderstore compatible Manifest.
 
 ## Fields
 * **Url**
@@ -22,7 +22,7 @@ The [ThunderstoreData](assetlink://Packages/com.passivepicasso.thunderkit/Editor
 
 ## PipelineJobs
 
-* [StageThunderstoreManifest](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Integrations/Thunderstore/StageThunderstoreManifest.cs)
+* [StageThunderstoreManifest](assetlink://GUID/dc52389347ae9634bbb7e74eba886518)
   - Generates a manifest.json file compatible with Thunderstore and outputs it to **StagingPaths** defined in this ManifestDatum.
 
 ## Remarks
@@ -31,4 +31,4 @@ Thunderstore Packages are required to contain a manifest.json file.
 
 This ManifestDatum collects additional Thunderstore specific information and identifies the Manifest as being Thunderstore compatible.
 
-The [StageThunderstoreManifest](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Integrations/Thunderstore/StageThunderstoreManifest.cs) PipelineJob looks for this ManifestDatum and will output a Manifest.json to  each StaginPath on each ThunderstoreData ManifestDatum attached to the current Manifests.
+The [StageThunderstoreManifest](assetlink://GUID/dc52389347ae9634bbb7e74eba886518) PipelineJob looks for this ManifestDatum and will output a Manifest.json to  each StaginPath on each ThunderstoreData ManifestDatum attached to the current Manifests.

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/ThunderstoreData.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/ThunderstoreData.md
@@ -22,7 +22,7 @@ The [ThunderstoreData](assetlink://GUID/e0a82fec78ebc734d9ad1346cd40b5f9) Manife
 
 ## PipelineJobs
 
-* [StageThunderstoreManifest](assetlink://GUID/dc52389347ae9634bbb7e74eba886518)
+* [StageThunderstoreManifest](documentation://GUID/74a0394c4eaea384e89e7a3688053c2b)
   - Generates a manifest.json file compatible with Thunderstore and outputs it to **StagingPaths** defined in this ManifestDatum.
 
 ## Remarks

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/UnityPackages.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/UnityPackages.md
@@ -8,7 +8,7 @@
 
 ---
 
-[UnityPackages](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/AssetReference.cs) stores an array of UnityPackage assets for use by the StageUnityPackages PipelineJob
+[UnityPackages](assetlink:/GUID/dda4ac7962f04724eacfeb26af5e2b75) stores an array of UnityPackage assets for use by the StageUnityPackages PipelineJob
 
 UnityPackages are an interface to Unity [Asset Packages](https://docs.unity3d.com/2018.4/Documentation/Manual/AssetPackages.html)
 

--- a/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/UnityPackages.md
+++ b/Documentation/ThunderKitDocumentation/Reference/ManifestDatums/UnityPackages.md
@@ -8,7 +8,7 @@
 
 ---
 
-[UnityPackages](assetlink:/GUID/dda4ac7962f04724eacfeb26af5e2b75) stores an array of UnityPackage assets for use by the StageUnityPackages PipelineJob
+[UnityPackages](assetlink://GUID/dda4ac7962f04724eacfeb26af5e2b75) stores an array of UnityPackage assets for use by the StageUnityPackages PipelineJob
 
 UnityPackages are an interface to Unity [Asset Packages](https://docs.unity3d.com/2018.4/Documentation/Manual/AssetPackages.html)
 

--- a/Documentation/ThunderKitDocumentation/Reference/PackageSources.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PackageSources.md
@@ -13,4 +13,4 @@ You can manage your PackageSources from [ThunderKit Settings](menulink://Tools/T
 
 Currently, ThunderKit provides two PackageSources, ThunderstoreSource and LocalThunderstoreSource as part of the Thunderstore integration for ThunderKit.
 
-Additional sources can be developed to support other stores, see the source code for [ThunderstoreSource](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Integrations/Thunderstore/ThunderstoreSource.cs) and [LocalThunderstoreSource](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Integrations/Thunderstore/LocalThunderstoreSource.cs) for some examples.
+Additional sources can be developed to support other stores, see the source code for [ThunderstoreSource](assetlink://GUID/52934b8837f3f754d97e00ab002548b0) and [LocalThunderstoreSource](assetlink://GUID/5888ac13fa454b64fa9fba76166e34ea) for some examples.

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents.md
@@ -22,9 +22,9 @@ ThunderKit comes with a number of already defined PathReferences for the BepInEx
 
 Please note that some adjustments may be needed for different games.
 
-  * [Common PathReference Assets](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Templates/PathReferences)
+  * [Common PathReference Assets](assetlink://GUID/8c6243a7bb8ce734ab8ae4ccf164bfb7)
 
-  * [BepInEx PathReference Assets](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Templates/BepInEx/PathReferences)
+  * [BepInEx PathReference Assets](assetlink://GUID/6733c4a0a9bdc9c44b9c486058325099)
 
 PathReferences can be used in a number of places in ThunderKit. ManifestDatum.StagingPaths, StageAssetBundles.BundleArtifactPath and all the Copy PipelineJobs allow you to use PathReferences by calling them in a tag.
 

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/AssetReference.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/AssetReference.md
@@ -8,7 +8,7 @@
 
 ---
 
-[AssetReference](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/AssetReference.cs) allows you to use the path of an asset.
+[AssetReference](assetlink://GUID/afeb2a60b1f31d44eaf0361730fb3f93) allows you to use the path of an asset.
 
 ## Fields
 * **Asset**

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/Constant.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/Constant.md
@@ -8,7 +8,7 @@
 
 ---
 
-[Constant](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/Constant.cs) will return the provided literal value
+[Constant](assetlink://GUID/cebc722807299b54bb8733330087d5e3) will return the provided literal value
 
 ## Fields
 

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/FindDirectory.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/FindDirectory.md
@@ -8,7 +8,7 @@
 
 ---
 
-[Find Directory](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/FindDirectory.cs) will find and return the name of a Directory
+[Find Directory](assetlink://GUID/d4fa9e4f9ff58a344b7da26cb499b387) will find and return the name of a Directory
 
 ## Fields
 

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/GameExecutable.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/GameExecutable.md
@@ -8,7 +8,7 @@
 
 ---
 
-[GameExecutable](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/GameExecutable.cs) will return the value of GameExecutable in your [ThunderKitSettings](menulink://Tools/ThunderKit/Settings)
+[GameExecutable](assetlink://GUID/590bd9fa6d6a2ba4b966390dfd0a9085) will return the value of GameExecutable in your [ThunderKitSettings](menulink://Tools/ThunderKit/Settings)
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/GamePath.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/GamePath.md
@@ -8,10 +8,10 @@
 
 ---
 
-[GamePath](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/GamePath.cs) will return the value of GamePath in your [ThunderKitSettings](menulink://Tools/ThunderKit/Settings)
+[GamePath](assetlink://GUID/df39480b01ece8c459c9db887486877f) will return the value of GamePath in your [ThunderKitSettings](menulink://Tools/ThunderKit/Settings)
 
 ## Remarks
 
 Use this to deploy files directly to the game folder.
 
-This is used by the [BepInEx Launch Pipeline](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Templates/BepInEx/Pipelines/Launch.asset) to deploy the winhttp.dll file to the games directory so that doorstop can intercept the application startup.
+This is used by the [BepInEx Launch Pipeline](assetlink://GUID/bee6483f5bcf7054b86d13321eef27e5) to deploy the winhttp.dll file to the games directory so that doorstop can intercept the application startup.

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/ManifestName.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/ManifestName.md
@@ -8,7 +8,7 @@
 
 ---
 
-[ManifestName](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/ManifestName.cs) can only be executed in the context of a Pipeline with an assigned Manifest.
+[ManifestName](assetlink:/GUID/2efd008a408bd8449ad573ac2d5003ce) can only be executed in the context of a Pipeline with an assigned Manifest.
 
 ## Context
 

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/ManifestName.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/ManifestName.md
@@ -8,7 +8,7 @@
 
 ---
 
-[ManifestName](assetlink:/GUID/2efd008a408bd8449ad573ac2d5003ce) can only be executed in the context of a Pipeline with an assigned Manifest.
+[ManifestName](assetlink://GUID/2efd008a408bd8449ad573ac2d5003ce) can only be executed in the context of a Pipeline with an assigned Manifest.
 
 ## Context
 

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/ManifestVersion.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/ManifestVersion.md
@@ -8,7 +8,7 @@
 
 ---
 
-[ManifestVersion](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/ManifestVersion.cs) can only be executed in the context of a Pipeline with an assigned Manifest.
+[ManifestVersion](assetlink://GUID/41b82db3744610d4ba6a7edd9df00836) can only be executed in the context of a Pipeline with an assigned Manifest.
 
 ## Context
 

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/OutputReference.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/OutputReference.md
@@ -8,7 +8,7 @@
 
 ---
 
-[OutputReference](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/OutputReference.cs) allows you to reference another PathReference using Unity's Asset system.
+[OutputReference](assetlink://GUID/0ceeada0f3a252c4fa6ec9b0c93543ce) allows you to reference another PathReference using Unity's Asset system.
 
 ## Fields
 * **Reference**

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/RegistryLookup.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/RegistryLookup.md
@@ -8,7 +8,7 @@
 
 ---
 
-[RegistryLookup](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/RegistryLookup.cs) will return the value at the specified value from the specified key
+[RegistryLookup](assetlink://GUID/67c19b2c06aa8614d99f5956929e3dab) will return the value at the specified value from the specified key
 
 ## Fields
 

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/Resolver.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/Resolver.md
@@ -8,7 +8,7 @@
 
 ---
 
-[Resolver](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/Resolver.cs) takes a string that it will resolve using the PathReference system.
+[Resolver](assetlink://GUID/6bfead62a54d1b04d9ce0a82f51655a1) takes a string that it will resolve using the PathReference system.
 
 ## Fields
 * **Value**

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/ThunderKitRoot.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/ThunderKitRoot.md
@@ -8,7 +8,7 @@
 
 ---
 
-[ThunderKitRoot](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/ThunderKitRoot.cs) returns "ThunderKit"
+[ThunderKitRoot](assetlink://GUID/49ea6c70a35243a4c83cfceb6d9f2ce7) returns "ThunderKit"
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PathComponents/WorkingDirectory.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathComponents/WorkingDirectory.md
@@ -8,7 +8,7 @@
 
 ---
 
-[WorkingDirectory](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Paths/Components/WorkingDirectory.cs) will return the current Process Working Directory
+[WorkingDirectory](assetlink://GUID/82f9860b00305774b85c0ef6b5e4b0d1) will return the current Process Working Directory
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PathReference.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PathReference.md
@@ -18,7 +18,7 @@ In the second a PathReference has access to the same information, plus it can ac
 
 In ThunderKit Pipelines and Manifests any place you can enter a path to a file or a folder, you can use a PathReference by invoking it in the field to ensure common paths are always used correctly.  You can invokea path reference by naming it in arrow brackets.
 
-For example, you can use the [ManifestPluginStaging](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Templates/PathReferences/ManifestPluginStaging.asset) PathReference in Staging Paths by calling it with arrow brackets.
+For example, you can use the [ManifestPluginStaging](assetlink://GUID/8bd8f966c2445394ab9c356e6227c6a0) PathReference in Staging Paths by calling it with arrow brackets.
 
 If you wanted to put all your Manifest's AssetBundles into a subfolder named AssetBundles in your mod output you add the following to your Manifest's AssetBundleDefinition's Staging Paths.
 
@@ -28,6 +28,6 @@ When the StageAssetBundles PipelineJob executes against your Manifest, it will o
 
 Where ProjectRoot is the name of the folder your project is in, and ManifestName is the value you entered for your Manifest's ManifestIdentity's Name field.
 
-ThunderKit comes with a number of already defined [PathReferences](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Templates/PathReferences). Please note that some adjustments may be needed for different games and mod loaders.
+ThunderKit comes with a number of already defined [PathReferences](assetlink://GUID/8c6243a7bb8ce734ab8ae4ccf164bfb7). Please note that some adjustments may be needed for different games and mod loaders.
 
 Finally it is important to note that fields which can use PathReferences do not automatically resolve. PipelineJobs must be built to resolve PathReferences using `PathReference.

--- a/Documentation/ThunderKitDocumentation/Reference/Pipeline.md
+++ b/Documentation/ThunderKitDocumentation/Reference/Pipeline.md
@@ -23,4 +23,4 @@ Each PipelineJob will use a ManifestDatum's StagingPaths to deploy its content, 
 
 Some PipelineJobs include the ability to Exclude Manifests.  This can be used to exclude Manifests which have special deployment requirements,  such as a Mod Loader.  In these situations you may need to have explicit control over where and how the content of that Manifest is deployed.  
 
-The [Default-BepInEx](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Templates/BepInEx/Manifests/Default-BepInEx.asset) template uses this to deploy BepInEx separately so that mods can properly be installed into its plugins, patchers and monomod folders.
+The [Default-BepInEx](assetlink://GUID/bc5e6d3336544e5361d16e63ddfca327) template uses this to deploy BepInEx separately so that mods can properly be installed into its plugins, patchers and monomod folders.

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs.md
@@ -16,9 +16,9 @@ PipelineJobs and ManifestDatums are paired together in ThunderKit.  When you cre
 
 Some pairs that already exist are;
 
-1. ManifestDatum [AssemblyDefinitions](assetlink://GUID/2b7e13dda513544419a89926bd12ad8a) and PipelineJob [StageAssemblies](assetlink://GUID/b5b20fac9c71fd64183cb7a8f359d73a) 
-2. ManifestDatum [AssetBundleDefinitions](assetlink://GUID/17d1008b78cb6e846889b7778282fbef) and PipelineJob [StageAssetBundles](assetlink://GUID/924ee63e6c016f14d8a1560b288f15a3) 
-3. ManifestDatum [UnityPackages](assetlink://GUID/dda4ac7962f04724eacfeb26af5e2b75) and PipelineJob [StageUnityPackages](assetlink://GUID/d087870ea8abaed4ca4c717444be0165) 
+1. ManifestDatum [AssemblyDefinitions](documentation://GUID/cef5acb6a795c5d4d9031261ea82e891) and PipelineJob [StageAssemblies](documentation://GUID/c18be5deeb5af6d48b59ed26056ba2fc)
+2. ManifestDatum [AssetBundleDefinitions](documentation://GUID/b3d3f798ec15f8240ad5105c46ce59f5) and PipelineJob [StageAssetBundles](documentation://GUID/346cbbd3f6c582441908249cf4067307)
+3. ManifestDatum [UnityPackages](documentation://GUID/e3fa281f0f933e64480e9eecdf057350) and PipelineJob [StageUnityPackages](documentation://GUID/915bcab14ba398e48b20a17d5e79b13b)
 
 Examine these pairs of types to gain a better understanding of how to build your own customized set of data.
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs.md
@@ -16,9 +16,9 @@ PipelineJobs and ManifestDatums are paired together in ThunderKit.  When you cre
 
 Some pairs that already exist are;
 
-1. ManifestDatum [AssemblyDefinitions](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/AssemblyDefinitions.cs) and PipelineJob [StageAssemblies](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageAssemblies.cs) 
-2. ManifestDatum [AssetBundleDefinitions](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/AssetBundleDefinitions.cs) and PipelineJob [StageAssetBundles](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageAssetBundles.cs) 
-3. ManifestDatum [UnityPackages](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/UnityPackages.cs) and PipelineJob [StageUnityPackages](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageUnityPackages.cs) 
+1. ManifestDatum [AssemblyDefinitions](assetlink://GUID/2b7e13dda513544419a89926bd12ad8a) and PipelineJob [StageAssemblies](assetlink://GUID/b5b20fac9c71fd64183cb7a8f359d73a) 
+2. ManifestDatum [AssetBundleDefinitions](assetlink://GUID/17d1008b78cb6e846889b7778282fbef) and PipelineJob [StageAssetBundles](assetlink://GUID/924ee63e6c016f14d8a1560b288f15a3) 
+3. ManifestDatum [UnityPackages](assetlink://GUID/dda4ac7962f04724eacfeb26af5e2b75) and PipelineJob [StageUnityPackages](assetlink://GUID/d087870ea8abaed4ca4c717444be0165) 
 
 Examine these pairs of types to gain a better understanding of how to build your own customized set of data.
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/Copy.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/Copy.md
@@ -8,7 +8,7 @@
 
 ---
 
-[Copy](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/Copy.cs) copy file(s) with configuration options
+[Copy](assetlink://GUID/03063c7a6ec04cc4c82c75cf9bcc8db8) copy file(s) with configuration options
 
 ## Fields
 * **Recursive**
@@ -33,13 +33,13 @@
 
 PathReferences are resources which can define dynamic paths, you can use them in fields that support PathReferences by invoking them with arrow brackets.
 
-For example if you use [ManifestPluginStaging](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Templates/PathReferences/ManifestPluginStaging.asset) in StagingPaths in your Manifest's ManifestDatums
-You could then use [ManifestPluginStaging](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Templates/PathReferences/ManifestPluginStaging.asset) in Copy with Per Manifest toggled to copy those files to another location
+For example if you use [ManifestPluginStaging](assetlink://GUID/8bd8f966c2445394ab9c356e6227c6a0) in StagingPaths in your Manifest's ManifestDatums
+You could then use [ManifestPluginStaging](assetlink://GUID/8bd8f966c2445394ab9c356e6227c6a0) in Copy with Per Manifest toggled to copy those files to another location
 
 This way you can deploy assets from multiple Manifests in your project simultaneously.
 
 However, if the Per Manifest option is not toggled, an error will occur when using those PathReferences as they utilize information from Manifests to complete their task
 
-The [BepInEx Launch Pipeline](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Templates/BepInEx/Pipelines/Launch.asset) uses Copy for its deployment steps.
+The [BepInEx Launch Pipeline](assetlink://GUID/bee6483f5bcf7054b86d13321eef27e5) uses Copy for its deployment steps.
 
 First it will use a Copy with Per Manifest and Recursive enabled, and Source Required disabled to copy plugins, patchers and monomods to the bepinex output directory.

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/Delete.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/Delete.md
@@ -8,7 +8,7 @@
 
 ---
 
-[Delete](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/Delete.cs) a file or directory
+[Delete](assetlink://GUID/87d65cc226c348d45aa1c6dddf3600a6) a file or directory
 
 ## Fields
 * **Recursive**

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/ExecutePipeline.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/ExecutePipeline.md
@@ -8,7 +8,7 @@
 
 ---
 
-[ExecutePipeline](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/ExecutePipeline.cs) will invoke an assigned Pipeline
+[ExecutePipeline](assetlink://GUID/50df4f9027e15e04b931a8d460fb22c5) will invoke an assigned Pipeline
 
 ## Fields
 * **Execute Pipeline**

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/ExecuteProcess.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/ExecuteProcess.md
@@ -8,7 +8,7 @@
 
 ---
 
-[ExecuteProcess](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/ExecuteProcess.cs) starts a new process
+[ExecuteProcess](assetlink://GUID/77f65d4371163fb4695da79ab8df0e84) starts a new process
 
 ## Fields
 * **Working Directory**
@@ -29,4 +29,4 @@ Execute Process can be used to launch games, external build processes, or any ot
 
 Use PathReferences to simplify the fields of ExecuteProcess and to provide a centralized set of variables to make it easier to manage multiple build pipelines.
 
-The [BepInEx Launch Pipeline](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Tempaltes/BepInEx/Pipelines/Launch.asset) uses Execute Process to launch the configured game and pass parameters necessary to load BepInEx with winhttp.dll and doorstop
+The [BepInEx Launch Pipeline](assetlink://GUID/bee6483f5bcf7054b86d13321eef27e5) uses Execute Process to launch the configured game and pass parameters necessary to load BepInEx with winhttp.dll and doorstop

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageAssemblies.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageAssemblies.md
@@ -8,7 +8,7 @@
 
 ---
 
-[StageAssemblies](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageAssemblies.cs) copies Assemblies built by unity out to StagingPaths
+[StageAssemblies](assetlink://GUID/b5b20fac9c71fd64183cb7a8f359d73a) copies Assemblies built by unity out to StagingPaths
 
 ## Fields
 * **Stage Debug Database**
@@ -21,7 +21,7 @@
 
 ## Required ManifestDatums
 
-* [AssemblyDefinitions](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/AssemblyDefinitions.cs)
+* [AssemblyDefinitions](assetlink://GUID/2b7e13dda513544419a89926bd12ad8a)
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageAssemblies.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageAssemblies.md
@@ -21,7 +21,7 @@
 
 ## Required ManifestDatums
 
-* [AssemblyDefinitions](assetlink://GUID/2b7e13dda513544419a89926bd12ad8a)
+* [AssemblyDefinitions](documentation://GUID/cef5acb6a795c5d4d9031261ea82e891)
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageAssetBundles.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageAssetBundles.md
@@ -8,7 +8,7 @@
 
 ---
 
-[StageAssetBundles](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageAssetBundles.cs) is an AssetBundle build system
+[StageAssetBundles](assetlink://GUID/924ee63e6c016f14d8a1560b288f15a3) is an AssetBundle build system
 
 ## Fields
 
@@ -27,7 +27,7 @@
 
 ## Required ManifestDatums
 
-* [AssetBundleDefinitions](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/AssetBundleDefinitions.cs)
+* [AssetBundleDefinitions](assetlink://GUID/17d1008b78cb6e846889b7778282fbef)
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageAssetBundles.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageAssetBundles.md
@@ -27,7 +27,7 @@
 
 ## Required ManifestDatums
 
-* [AssetBundleDefinitions](assetlink://GUID/17d1008b78cb6e846889b7778282fbef)
+* [AssetBundleDefinitions](documentation://GUID/b3d3f798ec15f8240ad5105c46ce59f5)
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageDependencies.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageDependencies.md
@@ -8,7 +8,7 @@
 
 ---
 
-[StageDependencies](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageDependencies.cs) deploys Dependencies found in Manifests that are not in the project Assets folder
+[StageDependencies](assetlink://GUID/1b4f4581088b47744a114c282abc085d) deploys Dependencies found in Manifests that are not in the project Assets folder
 
 ## Fields
 * **Staging Path**
@@ -17,7 +17,7 @@
 
 ## Required ManifestDatums
 
-* [ManifestIdentity](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/ManifestIdentity.cs)
+* [ManifestIdentity](assetlink://GUID/f22bb7fd1d3b56a48bc52f8e407901d6)
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageDependencies.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageDependencies.md
@@ -17,7 +17,7 @@
 
 ## Required ManifestDatums
 
-* [ManifestIdentity](assetlink://GUID/f22bb7fd1d3b56a48bc52f8e407901d6)
+* [ManifestIdentity](documentation://GUID/a94fe0e2c9006104bb1735bd177af5d7)
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageManifestFiles.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageManifestFiles.md
@@ -12,7 +12,7 @@
 
 ## Required ManifestDatums
 
-* [Files](assetlink://GUID/4b243ff405b33b94dbf5b6775dd9aa33)
+* [Files](documentation://GUID/be4e3f3da1c322a4982f44c2e5ac454d)
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageManifestFiles.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageManifestFiles.md
@@ -8,11 +8,11 @@
 
 ---
 
-[StageManifestFiles](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageManifestFiles.cs) will copy Assets to StagingPaths defined in the Files ManifestDatum
+[StageManifestFiles](assetlink://GUID/3570c76eb7a5c3c45942d9295a150917) will copy Assets to StagingPaths defined in the Files ManifestDatum
 
 ## Required ManifestDatums
 
-* [Files](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/Files.cs)
+* [Files](assetlink://GUID/4b243ff405b33b94dbf5b6775dd9aa33)
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageThunderstoreManifest.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageThunderstoreManifest.md
@@ -12,7 +12,7 @@
 
 ## Required ManifestDatums
 
-* [ThunderstoreData](assetlink://GUID/e0a82fec78ebc734d9ad1346cd40b5f9)
+* [ThunderstoreData](documentation://GUID/41a367ca4a0088f46b4327f0813dafdc)
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageThunderstoreManifest.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageThunderstoreManifest.md
@@ -8,12 +8,12 @@
 
 ---
 
-[StageThunderstoreManifest](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Integrations/Thunderstore/StageThunderstoreManifest.cs) creates Thunderstore manifest.json files
+[StageThunderstoreManifest](assetlink://GUID/dc52389347ae9634bbb7e74eba886518) creates Thunderstore manifest.json files
 
 ## Required ManifestDatums
 
-* [ThunderstoreData](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Integrations/Thunderstore/ThunderstoreData.cs)
+* [ThunderstoreData](assetlink://GUID/e0a82fec78ebc734d9ad1346cd40b5f9)
 
 ## Remarks
 
-The [StageThunderstoreManifest](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Integrations/Thunderstore/StageThunderstoreManifest.cs) PipelineJob looks for ThunderstoreData ManifestDatums and will output a manifest.json to each StaginPath on each ThunderstoreData ManifestDatum attached to the current Manifests.
+The [StageThunderstoreManifest](assetlink://GUID/dc52389347ae9634bbb7e74eba886518) PipelineJob looks for ThunderstoreData ManifestDatums and will output a manifest.json to each StaginPath on each ThunderstoreData ManifestDatum attached to the current Manifests.

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageUnityPackages.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageUnityPackages.md
@@ -12,7 +12,7 @@
 
 ## Required ManifestDatums
 
-* [UnityPackages](assetlink://GUID/dda4ac7962f04724eacfeb26af5e2b75)
+* [UnityPackages](documentation://GUID/e3fa281f0f933e64480e9eecdf057350)
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageUnityPackages.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/StageUnityPackages.md
@@ -8,11 +8,11 @@
 
 ---
 
-[StageUnityPackages](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/StageUnityPackages.cs) builds and deploys Unity Asset Packages
+[StageUnityPackages](assetlink://GUID/d087870ea8abaed4ca4c717444be0165) builds and deploys Unity Asset Packages
 
 ## Required ManifestDatums
 
-* [UnityPackages](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Manifests/Datum/UnityPackages.cs)
+* [UnityPackages](assetlink://GUID/dda4ac7962f04724eacfeb26af5e2b75)
 
 ## Remarks
 

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/Zip.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/Zip.md
@@ -32,6 +32,3 @@
 ## Remarks
 
 PathReferences are resources which can define dynamic paths, you can use them in fields that support PathReferences by invoking them with arrow brackets.
-
-
-The [BepInEx Package Pipeline](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Templates/BepInEx/Pipelines/Package.asset) uses Zip as a final publishing step.

--- a/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/Zip.md
+++ b/Documentation/ThunderKitDocumentation/Reference/PipelineJobs/Zip.md
@@ -8,7 +8,7 @@
 
 ---
 
-[Zip](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Pipelines/Jobs/Zip.cs) provides the ability to zip a directory
+[Zip](assetlink://GUID/8808e815b3ce9c94e9552cb1dee9e305) provides the ability to zip a directory
 
 ## Fields
 

--- a/Documentation/Tutorials/CreatingThunderKitSettings.md
+++ b/Documentation/Tutorials/CreatingThunderKitSettings.md
@@ -1,0 +1,39 @@
+---
+{ 
+	"title" : "Creating new ThunderKitSetting",
+	"headerClasses" : [ "bm4", "page-header-container" ],
+	"titleClasses" : [ "page-header" ],
+	"iconClasses" : [ "header-icon", "TK_ThunderKitSetting_2X_Icon" ]
+}
+
+---
+
+# Overview
+
+The [ThunderKitSetting](assetlink://GUID/87aed674429cded4f8f0b47b0c3d588c) is a ScriptableObject derived class that works via a Singleton aproach. A ThunderkitSetting can be used for storing specific data that ThunderKit can later use for it's Systems.
+
+ThunderKitSettings can be later inspected with the Inspector, or via Thunderkit's [Settings](menulink://Tools/ThunderKit/Settings) window, where more extensible features can be shown.
+
+To create a ThunderKitSetting, simply create a new class and inherit `ThunderkitSetting`, and add a using clause with `using ThunderKit.Core.Data`
+
+## ThunderKitSetting functionality
+
+### Initializing the ThunderKitSetting asset
+
+In case you need to initialize the settings file by putting default values, you can do so by overriding the `Initialize()` method. This method will only run Once when calling GetOrCreateSettings, and ThunderKit creates the Setting file instead of retreiving it.
+
+#### Remarks:
+* You can call `GetOrCreateSettings<T>()` from anywhere to get access to your Setting's data.
+
+### Creating the UI for your ThunderkitSetting
+
+ThunderkitSetting uses UIToolkit for displaying the setting interface, The setting interface can use VisualTreeAssets and Class Lists. While the usage of the aformentioned two arent covered in this tutorial, The tutorial does cover how to create the SettingsUI via code.
+
+ThunderKitSetting creates the SettingsUI for your Settings file by making it look like its being inspected thru the Inspector, while ommiting the m_Script object field, If you want to implement a more specific UI or UI behavior, override the `CreateSettingsUI(VisualElement rootElement)` method and ommit calling the base method.
+
+The ThunderKitSetting class comes with a `CreateStandardField(string fieldPath)` method, this method takes in the name of a serializedProperty of your asset and creates a PropertyField, alongside giving it custom CSS class qualities. This can be used to quickly create fields for your Settings UI.
+
+Once you add your fields to the rootElement, call `rootElement.Bind(new SerializedObject(this))`
+
+#### Remarks:
+* ThunderKitSetting accepts Markdown Elements.

--- a/Documentation/Tutorials/CreatingThunderKitSettings.md.meta
+++ b/Documentation/Tutorials/CreatingThunderKitSettings.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c35f912f12b142142ac729bcff1456aa
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/Tutorials/Tutorials.md
+++ b/Documentation/Tutorials/Tutorials.md
@@ -8,3 +8,5 @@
 }
 
 ---
+
+This section contains miscelaneous documents related to extending the editor's functionality using Thunderkit's systems. Including the creation of custom ManifestDatums, PathComponents, Pipelines and More.

--- a/Editor/Common/GetGuidMenu.cs
+++ b/Editor/Common/GetGuidMenu.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEditor;
+
+namespace ThunderKit.Common
+{
+    public static class GetGuidMenu
+    {
+        [MenuItem("Assets/Copy Guid")]
+        public static void GetGUID()
+        {
+            if (!Selection.activeObject)
+                return;
+
+            var path = AssetDatabase.GetAssetPath(Selection.activeObject);
+            var guid = AssetDatabase.AssetPathToGUID(path);
+            UnityEngine.GUIUtility.systemCopyBuffer = guid;
+        }
+    }
+}

--- a/Editor/Common/GetGuidMenu.cs.meta
+++ b/Editor/Common/GetGuidMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77eeee719e92f524c8d140fb23d62404
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Core/Windows/Documentation.cs
+++ b/Editor/Core/Windows/Documentation.cs
@@ -44,12 +44,21 @@ namespace ThunderKit.Core.Windows
                     string path = schemelessUri.StartsWith("GUID/") ?
                     AssetDatabase.GUIDToAssetPath(schemelessUri.Substring("GUID/".Length))
                     : schemelessUri;
-                    Debug.Log(path);
 
                     ShowThunderKitDocumentation(path);
                 },
                 label =>
                 {
+                    string schemelessUri = label.tooltip.Substring("documentation://".Length);
+
+                    if (schemelessUri.Length != 0)
+                    {
+                        string path = schemelessUri.StartsWith("GUID/") ?
+                        AssetDatabase.GUIDToAssetPath(schemelessUri.Substring("GUID/".Length))
+                        : schemelessUri;
+                        label.tooltip = $"documentation://{path}";
+                    }
+
                     var container = new VisualElement();
 
                     var icon = new Image();

--- a/Editor/Core/Windows/Documentation.cs
+++ b/Editor/Core/Windows/Documentation.cs
@@ -37,8 +37,29 @@ namespace ThunderKit.Core.Windows
                 "documentation",
                 link =>
                 {
-                    var path = link.Substring("documentation://".Length);
+                    var schemelessUri = link.Substring("documentation://".Length);
+
+                    if (schemelessUri.Length == 0) return;
+
+                    string path = schemelessUri.StartsWith("GUID/") ?
+                    AssetDatabase.GUIDToAssetPath(schemelessUri.Substring("GUID/".Length))
+                    : schemelessUri;
+                    Debug.Log(path);
+
                     ShowThunderKitDocumentation(path);
+                },
+                label =>
+                {
+                    var container = new VisualElement();
+
+                    var icon = new Image();
+                    icon.AddToClassList("asset-icon");
+                    icon.image = AssetDatabase.LoadAssetAtPath<Texture>(AssetDatabase.GUIDToAssetPath("2f1c3b93b0c7f4046a4d826cc0460f12"));
+
+                    container.Add(icon);
+                    container.Add(label);
+
+                    return container;
                 });
         }
 

--- a/Editor/Markdown/MarkdownElement.cs
+++ b/Editor/Markdown/MarkdownElement.cs
@@ -73,7 +73,18 @@ namespace ThunderKit.Markdown
             this.AddManipulator(new ContextualMenuManipulator((evt) =>
             {
                 if (MarkdownDataType == MarkdownDataType.Implicit || MarkdownDataType == MarkdownDataType.Source)
+                {
                     evt.menu.AppendAction("Edit Markdown", OpenMarkdown);
+                    evt.menu.AppendAction("Select Markdown Source", (dma) =>
+                    {
+                        var asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(data);
+                        if (asset != null)
+                        {
+                            EditorGUIUtility.PingObject(asset);
+                            Selection.activeObject = asset;
+                        }
+                    });
+                }
             }));
         }
 

--- a/Editor/Markdown/MarkdownElement.cs
+++ b/Editor/Markdown/MarkdownElement.cs
@@ -8,6 +8,7 @@ using ThunderKit.Markdown.Extensions.GenericAttributes;
 using ThunderKit.Markdown.Extensions.Json;
 
 using UnityEditor;
+using UnityEditorInternal;
 using UnityEngine;
 #if UNITY_2019_1_OR_NEWER
 using UnityEngine.UIElements;
@@ -69,6 +70,33 @@ namespace ThunderKit.Markdown
 #elif UNITY_2018_1_OR_NEWER
             AddSheet(MarkdownStylePath, "2018");
 #endif
+            this.AddManipulator(new ContextualMenuManipulator((evt) =>
+            {
+                if (MarkdownDataType == MarkdownDataType.Implicit || MarkdownDataType == MarkdownDataType.Source)
+                    evt.menu.AppendAction("Edit Markdown", OpenMarkdown);
+            }));
+        }
+
+        private void OpenMarkdown(DropdownMenuAction obj)
+        {
+            try
+            {
+                string path = Path.GetFullPath(Data);
+                if(File.Exists(path))
+                {
+                    if(string.Compare(Path.GetExtension(path), ".md", true) != 0)
+                    {
+                        throw new InvalidOperationException($"The file {path} is not a file with a markdown extension (.md)");
+                    }
+                    System.Diagnostics.Process.Start(path);
+                    return;
+                }
+                throw new NullReferenceException($"No file exists in {path}");
+            }
+            catch (Exception ex)
+            {
+                Debug.Log(ex);
+            }
         }
 
         private void MarkdownFileWatcher_DocumentUpdated(object sender, (string path, MarkdownFileWatcher.ChangeType change) e)

--- a/Editor/Markdown/ObjectRenderer/Inlines/LinkInlineRenderer.cs
+++ b/Editor/Markdown/ObjectRenderer/Inlines/LinkInlineRenderer.cs
@@ -7,7 +7,6 @@ using System.Text.RegularExpressions;
 using Markdig.Renderers.Html;
 #if UNITY_2019_1_OR_NEWER
 using UnityEngine.UIElements;
-using UnityEditor.UIElements;
 #else
 using UnityEngine.Experimental.UIElements;
 #endif
@@ -33,7 +32,12 @@ namespace ThunderKit.Markdown.ObjectRenderers
             {
                 var schemelessUri = link.Substring("assetlink://".Length);
                 if (schemelessUri.Length == 0) return;
-                var asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(schemelessUri);
+                
+                string path = schemelessUri.StartsWith("GUID/") ? 
+                AssetDatabase.GUIDToAssetPath(schemelessUri.Substring("GUID/".Length)) 
+                : schemelessUri;
+
+                var asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path);
                 EditorGUIUtility.PingObject(asset);
                 Selection.activeObject = asset;
             },
@@ -43,11 +47,15 @@ namespace ThunderKit.Markdown.ObjectRenderers
                 if (schemelessUri.Length == 0)
                     return label;
 
+                string path = schemelessUri.StartsWith("GUID/") ?
+                AssetDatabase.GUIDToAssetPath(schemelessUri.Substring("GUID/".Length))
+                : schemelessUri;
+
                 var container = new VisualElement();
 
                 var icon = new Image();
                 icon.AddToClassList("asset-icon");
-                icon.image = AssetDatabase.GetCachedIcon(schemelessUri);
+                icon.image = AssetDatabase.GetCachedIcon(path);
 
                 container.Add(icon);
                 container.Add(label);

--- a/Editor/Markdown/ObjectRenderer/Inlines/LinkInlineRenderer.cs
+++ b/Editor/Markdown/ObjectRenderer/Inlines/LinkInlineRenderer.cs
@@ -50,6 +50,7 @@ namespace ThunderKit.Markdown.ObjectRenderers
                 string path = schemelessUri.StartsWith("GUID/") ?
                 AssetDatabase.GUIDToAssetPath(schemelessUri.Substring("GUID/".Length))
                 : schemelessUri;
+                label.tooltip = $"assetlink://{path}";
 
                 var container = new VisualElement();
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,26 @@ These initial steps are the universal basic setup for any ThunderKit project.
     - Unity 2018 does not full integration for Git and operates on an installed version
 3. Create a new Unity Project with the installed version of Unity
 4. Install ThunderKit
-      - Navigate to the Project folder with your file explorer and open the Packages folder 
-      - Open the manifest.json file in this folder and add the following to the top of dependencies
-      `"com.passivepicasso.thunderkit":"https://github.com/PassivePicasso/ThunderKit.git",` 
-      - Save and close the manifest.json file and focus Unity to complete the process.
-
+    - there are two ways of installing thunderkit.
+    - Manual:
+        - Navigate to the Project folder with your file explorer and open the Packages folder 
+        - Open the manifest.json file in this folder and add the following to the top of dependencies
+        `"com.passivepicasso.thunderkit":"https://github.com/PassivePicasso/ThunderKit.git",` 
+        - Save and close the manifest.json file and focus Unity to complete the process.
+    - Unity Package Manager
+        - Open the Unity Package Manager
+        - Click the Plus icon at the top left corner
+        - Select "Add Package from Git URL..."
+        - Paste the following on the text field
+        `"com.passivepicasso.thunderkit":"https://github.com/PassivePicasso/ThunderKit.git",` 
+        - Click add and close the package manager
 5. Verify that the [ThunderKit Settings](menulink://Tools/ThunderKit/Settings) window opened automatically.
     - If the ThunderKit Settings window did not open after the installation completes, check the Console for errors
 
-6. Click on Locate Game under the ThunderKit settings to locate and select the games executable
+6. Click on Browse under the ThunderKit settings to locate and select the games executable
+7. Configure the import process to your liking.
+    * More information about the import options can be found on the Thunderkit Documentation.
+8. Hit Import
       * It may take some time for ThunderKit and Unity to complete the configuration
 7. Open the project window from the main menu via Windows/General/Project
 8. Create a Manifest by right clicking in any folder under assets and selecting ThunderKit/Manifest

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The Simulate field will execute an analysis of the AssetBundles and report in th
 
 ## Redistributable  Libraries
 
-If you need to create asset libraries that other developers need to depend on, use [UnityPackages](assetlink://Packages/com.passivepicasso.thunderkit/Editor/Core/Data/UnityPackage.cs) to simplify that process.
+If you need to create asset libraries that other developers need to depend on, use [UnityPackages](assetlink://GUID/aa12c443303b4d54e9a56ac3acc7bd25) to simplify that process.
 UnityPackages is ThunderKit tooling for [Unity Manual - Asset Packages](https://docs.unity3d.com/2018.4/Documentation/Manual/AssetPackages.html)
 
 ### Using UnityPackages 

--- a/Templates/BepInEx/Pipelines/BepInExLaunch.asset
+++ b/Templates/BepInEx/Pipelines/BepInExLaunch.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Data:
   - {fileID: 114525731783530820}
+  QuickAccess: 0
   manifest: {fileID: 0}
-  runLog: []
 --- !u!114 &114525731783530820
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -28,9 +28,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 77f65d4371163fb4695da79ab8df0e84, type: 3}
   m_Name: ExecuteProcess
   m_EditorClassIdentifier: 
-  Errored: 0
-  ErrorMessage: 
-  ErrorStacktrace: 
   Active: 1
   workingDirectory: <BepInExPackDestination>
   executable: <GameExecutable>

--- a/Third Party Notices.md
+++ b/Third Party Notices.md
@@ -7,40 +7,40 @@ This package contains third-party software components governed by the license(s)
 * `Copyright (c) 2018, Alexandre Mutel`
 * [https://github.com/xoofx/markdig](https://github.com/xoofx/markdig)
 * License : [BSD 2-Clause "Simplified"](https://github.com/xoofx/markdig/blob/master/license.txt)
-* [Local License](assetlink://Packages/com.passivepicasso.thunderkit/Editor/ThirdParty/Markdig/license.txt)
+* [Local License](assetlink://GUID/a3cea14f6fefce94082492a3e8df5358)
 
 ## Cascadia Code
 
 * `Copyright (c) 2019 - Present, Microsoft Corporation,`
 * [https://github.com/microsoft/cascadia-code](https://github.com/microsoft/cascadia-code)
 * License:  [SIL Open Font License, Version 1.1](http://scripts.sil.org/OFL)
-* [Local License](assetlink://Packages/com.passivepicasso.thunderkit/Editor/ThirdParty/CascadiaCode/LICENSE.txt)
+* [Local License](assetlink://GUID/85695bdaec736cc46b8c43c5373e2bb9)
 
 ## SharpCompress (v21.0)
 
 * `Copyright (c) 2014  Adam Hathcock`
 * [https://github.com/adamhathcock/sharpcompress](https://github.com/adamhathcock/sharpcompress)
 * License:  [The MIT License](https://github.com/adamhathcock/sharpcompress/blob/master/LICENSE.txt)
-* [Local License](assetlink://Packages/com.passivepicasso.thunderkit/Editor/ThirdParty/SharpCompress/LICENSE.txt)
+* [Local License](assetlink://GUID/4b02e94a011feed41b58d7b116780ac0)
 
 ## Markdown Test File
 
 * `Copyright (c) 2017 Max Stoiber`
 * [https://github.com/mxstbr/markdown-test-file](https://github.com/mxstbr/markdown-test-file)
 * License:  [The MIT License](https://github.com/mxstbr/markdown-test-file/blob/master/LICENSE)
-* [Local License](assetlink://Packages/com.passivepicasso.thunderkit/Editor/ThirdParty/MarkdownTestFile/LICENSE.txt)
+* [Local License](assetlink://GUID/d2e46d9c9f4288b4e85e7ba448d018d6)
 
 ## Unity Toolbar Extender
 
 * `Copyright (c) 2018 Marijn Zwemmer`
 * [https://github.com/marijnz/unity-toolbar-extender](https://github.com/marijnz/unity-toolbar-extender)
 * License:  [The MIT License](https://github.com/marijnz/unity-toolbar-extender/blob/master/LICENSE)
-* [Local License](assetlink://Packages/com.passivepicasso.thunderkit/Editor/ThirdParty/UnityToolbarExtender/LICENSE.txt)
+* [Local License](assetlink://GUID/47661bbef8f7c4848bc22482e40dbd26)
 
 ## AssetsTools.NET 
 
 * `Copyright (c) 2020 nesrak1`
 * [https://github.com/nesrak1/AssetsTools.NET](https://github.com/nesrak1/AssetsTools.NET)
 * License:  [The MIT License](https://github.com/nesrak1/AssetsTools.NET/blob/master/LICENSE)
-* [Local License](assetlink://Packages/com.passivepicasso.thunderkit/Editor/ThirdParty/AssetsTools.NET/LICENSE.txt)
+* [Local License](assetlink://GUID/8b84cdaefe6cec6489553433fa4cfcf6)
 * This library was modified to remove it's Mono.Cecil dependency for compatibility reasons


### PR DESCRIPTION
This pull request modifies certain aspects of the documentation system and markdown system to improve their functionality.

Notable Changes:

* the assetLink scheme now supports GUID's, a valid GUID assetLink needs to add a `GUID/` string right after the assetlink:// declaration.
    * Example: `[MarkdownElement](assetlink://GUID/ec19b76b765719a4fb4383a4fa9324ea)`
    * Path based assetLinks still work properly.
* documentation scheme also supports GUID's, it uses the same valid system as the assetLink.
* documentation links now have a TKDocumentation icon at the left, to signify the link sends you to a different page.
* edited documentation markdown files so it uses the new GUID system of assetLinks
* MarkdownElements now have a contextMenu when the markdown data type is either implicit, or source.
    * `Edit Markdown`: Opens the markdown file associated to the document page with it's default program.
    * `Select Markdown Source`: Selects and Pings the markdown file associated to the document page.
* Modified the Changelog file so it adds the start of the 5.0.0 changelog, currently just includes Lorem ipsum
* Updated readme file with an extended version of how to install thunderkit (Either by manual modification of the manifest.json) or by the unity package manager's Add from git source. Alongside this, i added new steps regarding browsing for the .exe and then configuring the import process.
* Added a very basic ThunderKitSetting creation documentation page.
* Added a GetGUID context menu, located under common.