### PR TITLE
Improvements to import extensions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,0 @@
-﻿[*.cs]
-
-# CS0618: Type or member is obsolete
-dotnet_diagnostic.CS0618.severity = silent

--- a/Editor/Common/EnumExtensions.cs
+++ b/Editor/Common/EnumExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ThunderKit.Common
+{
+    public static class EnumExtensions
+    {
+        public static string GetDescription<T>(this T enumValue) where T : struct, IConvertible
+        {
+            if (!typeof(T).IsEnum)
+                return null;
+
+            var description = enumValue.ToString();
+            var fieldInfo = enumValue.GetType().GetField(enumValue.ToString());
+
+            if (fieldInfo != null)
+            {
+                var attrs = fieldInfo.GetCustomAttributes(typeof(DescriptionAttribute), true);
+                if (attrs != null && attrs.Length > 0)
+                {
+                    description = ((DescriptionAttribute)attrs[0]).Description;
+                }
+            }
+
+            return description;
+        }
+    }
+}

--- a/Editor/Common/EnumExtensions.cs.meta
+++ b/Editor/Common/EnumExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f270fbf79d57c85449fce7be07ffd575
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Core/Config/Common/ImportAssemblies.cs
+++ b/Editor/Core/Config/Common/ImportAssemblies.cs
@@ -65,6 +65,7 @@ namespace ThunderKit.Core.Config
                 .Where(t => !t.IsAbstract && !t.IsInterface)
                 .Select(t => CreateInstance(t) as T)
                 .Where(t => t != null)
+                .OrderByDescending(t => t.Priority)
                 .ToList();
             importers.Sort();
             return importers;

--- a/Editor/Core/Config/ExtensionPoints/OptionalExecutor.cs
+++ b/Editor/Core/Config/ExtensionPoints/OptionalExecutor.cs
@@ -19,12 +19,15 @@ namespace ThunderKit.Core.Config
 
         public bool enabled;
 
+        public virtual string Description { get; }
+
         public VisualElement CreateUI()
         {
             var element = new VisualElement { name = "extension-item" };
 
             var header = new VisualElement { name = "extension-item-header" };
             header.AddToClassList("thunderkit-field");
+            header.tooltip = string.IsNullOrEmpty(Description) ? $"(Import Extension Priority: {Priority})" : $"{Description}\n\n(Import Extension Priority: {Priority}";
             var label = new Label { name = "extension-label", text = Name };
             header.Add(label);
             var toggle = new Toggle { name = "extension-enabled-toggle", bindingPath = nameof(OptionalExecutor.enabled) };

--- a/Editor/Core/Utilities/Extensions.cs
+++ b/Editor/Core/Utilities/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using ThunderKit.Core.Data;
 using UnityEditor;
@@ -29,6 +30,5 @@ namespace ThunderKit.Core.Utilities
         {
             return (input & flag) == flag;
         }
-
     }
 }


### PR DESCRIPTION
This pull request improves the import extensions system in the following ways:
- Added enum extensions, allows you to properly use the Description attribute on enums, this is used for the ror2 importer
- ImportAssemblies now orders the assembly processors by priority
- Optional executor now has description property, Description priority is printed on the optional executor's header label, if the description is null or empty, it only shows the priority value.