### PR TITLE
Fix stage assemblies building only the first assembly

### DIFF
--- a/Editor/Core/Pipelines/Jobs/StageAssemblies.cs
+++ b/Editor/Core/Pipelines/Jobs/StageAssemblies.cs
@@ -183,11 +183,11 @@ namespace ThunderKit.Core.Pipelines.Jobs
                     File.Delete(assemblyOutputPath);
                 BuildStatus.Add(builder);
                 builder.Build();
-            }
 
-            while (EditorApplication.isCompiling)
-            {
-                await Task.Delay(100);
+                while (builder.status != AssemblyBuilderStatus.Finished)
+                {
+                    await Task.Delay(100);
+                }
             }
         }
 


### PR DESCRIPTION
Unity AssemblyBuilder doesn't support parallel builds, so I moved waiting loop in the build loop