### PR TITLE
Minor Change List

### DIFF
--- a/Editor/Addressable/Config/AddressableGraphicsImport.cs
+++ b/Editor/Addressable/Config/AddressableGraphicsImport.cs
@@ -9,6 +9,8 @@ namespace ThunderKit.Addressable.Tools
 {
     public abstract class AddressableGraphicsImport : OptionalExecutor
     {
+        public const string AddressableSettingsTypeName = "ThunderKit.Addressable.Tools.AddressableGraphicsSettings, ThunderKit.Addressable.Tools, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+
         public override int Priority => Constants.Priority.AddressableGraphicsImport;
 
         public virtual string CustomDeferredReflection => null;
@@ -17,26 +19,25 @@ namespace ThunderKit.Addressable.Tools
 
         public sealed override bool Execute()
         {
-            var settingsType = Type.GetType("ThunderKit.Addressable.Tools.AddressableGraphicsSettings, ThunderKit.Addressable.Tools, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
-            if (settingsType == null)
+            if (ThunderKitSetting.TryGetSetting(out var settings, AddressableSettingsTypeName))
             {
-                Debug.Log("AddressableGraphicsSettings not loaded, skipping");
-                return true;
+                var settingsSo = new SerializedObject(settings);
+                var customDeferredReflection = settingsSo.FindProperty("CustomDeferredReflection");
+                var customDeferredScreenspaceShadows = settingsSo.FindProperty("CustomDeferredScreenspaceShadows");
+                var customDeferredShading = settingsSo.FindProperty("CustomDeferredShading");
+
+                customDeferredReflection.stringValue = CustomDeferredReflection;
+                customDeferredScreenspaceShadows.stringValue = CustomDeferredScreenspaceShadows;
+                customDeferredShading.stringValue = CustomDeferredShading;
+
+                settingsSo.ApplyModifiedPropertiesWithoutUndo();
             }
+            else
+                Debug.Log("AddressableGraphicsSettings not loaded, skipping");
 
-            var settings = ThunderKitSetting.GetOrCreateSettings(settingsType) as ThunderKitSetting;
-            var settingsSo = new SerializedObject(settings);
-
-            var customDeferredReflection = settingsSo.FindProperty("CustomDeferredReflection");
-            var customDeferredScreenspaceShadows = settingsSo.FindProperty("CustomDeferredScreenspaceShadows");
-            var customDeferredShading = settingsSo.FindProperty("CustomDeferredShading");
-
-            customDeferredReflection.stringValue = CustomDeferredReflection;
-            customDeferredScreenspaceShadows.stringValue = CustomDeferredScreenspaceShadows;
-            customDeferredShading.stringValue = CustomDeferredShading;
-
-            settingsSo.ApplyModifiedPropertiesWithoutUndo();
-            return true;
+                return true;
         }
+
+
     }
 }

--- a/Editor/Core/Data/ThunderKitSetting.cs
+++ b/Editor/Core/Data/ThunderKitSetting.cs
@@ -66,10 +66,10 @@ namespace ThunderKit.Core.Data
             return ScriptableHelper.EnsureAsset<T>(assetPath, settings => settings.Initialize());
         }
 
-        public  static object GetOrCreateSettings(Type settingType)
+        public static object GetOrCreateSettings(Type settingType)
         {
             var tksType = typeof(ThunderKitSetting);
-            if (!tksType.IsAssignableFrom(settingType)) 
+            if (!tksType.IsAssignableFrom(settingType))
                 throw new ArgumentException($"parameter t is typeof({settingType.Name}), t must be assignable to typeof({tksType.Name}");
 
             string assetPath = $"Assets/ThunderKitSettings/{settingType.Name}.asset";
@@ -81,6 +81,19 @@ namespace ThunderKit.Core.Data
                 setting.Initialize();
             });
         }
+
+        public static bool TryGetSetting(out ThunderKitSetting setting, string typeName)
+        {
+            var settingsType = Type.GetType(typeName);
+            if (settingsType != null && settingsType.IsInstanceOfType(typeof(ThunderKitSetting)))
+            {
+                setting = GetOrCreateSettings(settingsType) as ThunderKitSetting;
+                return true;
+            }
+            setting = null;
+            return false;
+        }
+
 
         public virtual void Initialize() { }
         public virtual IEnumerable<string> Keywords() => Enumerable.Empty<string>();
@@ -94,7 +107,7 @@ namespace ThunderKit.Core.Data
                 EditorGUIUtility.labelWidth = 250;
                 EditorGUI.BeginChangeCheck();
                 DrawPropertiesExcluding(serializedObject, "m_Script");
-                if(EditorGUI.EndChangeCheck())
+                if (EditorGUI.EndChangeCheck())
                 {
                     serializedObject.ApplyModifiedProperties();
                     OnChanged?.Invoke();

--- a/Editor/Core/Manifests/Datum/AssemblyDefinitions.cs
+++ b/Editor/Core/Manifests/Datum/AssemblyDefinitions.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEditorInternal;
 
-namespace ThunderKit.Core.Manifests.Datums
+namespace ThunderKit.Core.Manifests.Datum
 {
     public class AssemblyDefinitions : ManifestDatum
     {

--- a/Editor/Core/Manifests/Datum/AssetBundleDefinitions.cs
+++ b/Editor/Core/Manifests/Datum/AssetBundleDefinitions.cs
@@ -2,7 +2,7 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace ThunderKit.Core.Manifests.Datums
+namespace ThunderKit.Core.Manifests.Datum
 {
 
     [Serializable]

--- a/Editor/Core/Manifests/Datum/UnityPackages.cs
+++ b/Editor/Core/Manifests/Datum/UnityPackages.cs
@@ -1,6 +1,6 @@
 ﻿using ThunderKit.Core.Data;
 
-namespace ThunderKit.Core.Manifests.Datums
+namespace ThunderKit.Core.Manifests.Datum
 {
     public class UnityPackages : ManifestDatum
     {

--- a/Editor/Core/Pipelines/Jobs/StageAssemblies.cs
+++ b/Editor/Core/Pipelines/Jobs/StageAssemblies.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using ThunderKit.Core.Attributes;
-using ThunderKit.Core.Manifests.Datums;
+using ThunderKit.Core.Manifests.Datum;
 using ThunderKit.Core.Paths;
 using UnityEditor;
 using System.Threading.Tasks;

--- a/Editor/Core/Pipelines/Jobs/StageAssetBundles.cs
+++ b/Editor/Core/Pipelines/Jobs/StageAssetBundles.cs
@@ -5,7 +5,7 @@ using System.Text;
 using ThunderKit.Core.Attributes;
 using System.Threading.Tasks;
 using ThunderKit.Core.Data;
-using ThunderKit.Core.Manifests.Datums;
+using ThunderKit.Core.Manifests.Datum;
 using ThunderKit.Core.Paths;
 using ThunderKit.Core.Pipelines;
 using UnityEditor;

--- a/Editor/Core/Pipelines/Jobs/StageUnityPackages.cs
+++ b/Editor/Core/Pipelines/Jobs/StageUnityPackages.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Text.RegularExpressions;
 using ThunderKit.Core.Attributes;
-using ThunderKit.Core.Manifests.Datums;
+using ThunderKit.Core.Manifests.Datum;
 using ThunderKit.Core.Paths;
 using System.Threading.Tasks;
 using UnityEditor;

--- a/Editor/ThirdParty/AssetsTools.NET/AssetsTools.NET/Extra/AssetsManager/AssetsManager.cs
+++ b/Editor/ThirdParty/AssetsTools.NET/AssetsTools.NET/Extra/AssetsManager/AssetsManager.cs
@@ -71,6 +71,18 @@ namespace AssetsTools.NET.Extra
                 AssetsFileInstance assetsInst = files[index];
                 assetsInst.file.Close();
                 files.Remove(assetsInst);
+                assetsInst.parentBundle.loadedAssetsFiles.Remove(assetsInst);
+                return true;
+            }
+            return false;
+        }
+
+        public bool UnloadAssetsFile(AssetsFileInstance assetsInst)
+        {
+            if(files.Contains(assetsInst))
+            {
+                assetsInst.file.Close();
+                files.Remove(assetsInst);
                 return true;
             }
             return false;


### PR DESCRIPTION
- A few minor changes to AssetsTools that done for the purpose of making Bundlekit more functional with Thunderkit's version of AssetsTools.
- Added new method to `public static bool TryGetSetting(out ThunderKitSetting setting, string typeName)` to **Editor/Core/Data/ThunderKitSetting.cs**. This is now used in **Editor/Addressable/Config/AddressableGraphicsImport.cs** for the purpose of establishing whether type ``AddressableGraphicsSettings`` has been found. Plan to use method for establishing whether AddressableImport plugin has been loaded.
- Fixed an issue where the `AssemblyDefinitions`, `AssetBundleDefinitions`, `UnityPackages `manifest datum classes were in namespace `ThunderKit.Core.Manifests.Datums` instead of `ThunderKit.Core.Manifests.Datum` for future consistency. Don't really mind if you deny this part due to compatibility with packages that might reference these, just noticed it and was bugging me.