### PR TITLE
Added StrictDictionaryReplace toggle in Copy pipeline

### DIFF
--- a/Editor/Core/Pipelines/Jobs/Copy.cs
+++ b/Editor/Core/Pipelines/Jobs/Copy.cs
@@ -13,7 +13,12 @@ namespace ThunderKit.Core.Pipelines.Jobs
     [PipelineSupport(typeof(Pipeline))]
     public class Copy : FlowPipelineJob
     {
+        [Tooltip("While enabled, Replaces the directory strictly (removes all custom made files in destination folder)")]
+        public bool StrictDictionaryReplace = true;
+
+        [Tooltip("While enabled, will copy entire specified directory & subdirectories. Source and destination should be folders")]
         public bool Recursive;
+
         [Tooltip("While enabled, will error when the source is not found (default: true)")]
         public bool SourceRequired = true;
 
@@ -22,76 +27,122 @@ namespace ThunderKit.Core.Pipelines.Jobs
 
         [PathReferenceResolver]
         public string Source;
+
         [PathReferenceResolver]
         public string Destination;
 
+        private string CopyStatement;
+
         protected override Task ExecuteInternal(Pipeline pipeline)
         {
-            var copyStatement = $"``` {Source} ``` to ``` {Destination} ```\r\n";
-            var source = string.Empty;
-            try
-            {
-                source = Source.Resolve(pipeline, this);
-            }
-            catch (Exception e)
-            {
-                if (SourceRequired)
-                    throw new InvalidOperationException($"{copyStatement} Failed to resolve source when source is required", e);
-            }
-            if (SourceRequired && string.IsNullOrEmpty(source)) throw new ArgumentException($"{copyStatement} Required {nameof(Source)} is empty");
-            if (!SourceRequired && string.IsNullOrEmpty(source))
-            {
-                pipeline.Log(LogLevel.Information, $"{copyStatement} Source not specified and is not required, copy skipped");
+            CopyStatement = $"``` {Source} ``` to ``` {Destination} ```\r\n";
+
+            var source = ResolveSource(pipeline);
+            if (!ValidateSource(pipeline, source))
                 return Task.CompletedTask;
-            }
+
+            var isSourceFile = IsSourceFile(source);
             var destination = Destination.Resolve(pipeline, this);
 
-            bool sourceIsFile = false;
-
-            try
-            {
-                sourceIsFile = !File.GetAttributes(source).HasFlag(FileAttributes.Directory);
-            }
-            catch (Exception e)
-            {
-                if (SourceRequired)
-                    throw new InvalidOperationException($"{copyStatement} Failed to check {nameof(Source)} attributes when {nameof(Source)} is required", e);
-            }
-
-            if (Recursive)
-            {
-                if (!Directory.Exists(source) && !SourceRequired)
-                {
-                    pipeline.Log(LogLevel.Information, $"{copyStatement} Source not found and is not required, copy skipped");
-                    return Task.CompletedTask;
-                }
-                else if (!Directory.Exists(source) && SourceRequired)
-                {
-                    throw new ArgumentException($"{copyStatement} Source not found and is required");
-                }
-                else if (sourceIsFile)
-                    throw new ArgumentException($"{copyStatement} Expected Directory for recursive copy, Recieved file path: {source}");
-            }
-
             if (EstablishDestination)
-                Directory.CreateDirectory(sourceIsFile ? Path.GetDirectoryName(destination) : destination);
+                Directory.CreateDirectory((isSourceFile ? Path.GetDirectoryName(destination) : destination)!);
 
             if (Recursive)
-            {
-                FileUtil.ReplaceDirectory(source, destination);
-                int i = 1;
-                var copiedFiles = Directory.EnumerateFiles(destination, "*", SearchOption.AllDirectories)
-                    .Prepend("Copied Files")
-                    .Aggregate((a, b) => $"{a}\r\n\r\n {i++}. {b}");
-                pipeline.Log(LogLevel.Information, $"{copyStatement}\r\n\r\nCopied ``` {source} ``` to ``` {destination} ```", copiedFiles);
-            }
+                ExecuteRecursiveCopy(pipeline, isSourceFile, source, destination);
             else
             {
                 FileUtil.ReplaceFile(source, destination);
-                pipeline.Log(LogLevel.Information, $"{copyStatement}\r\n\r\n``` {source} ``` to ``` {destination} ```");
+                pipeline.Log(LogLevel.Information, $"{CopyStatement}\r\n\r\n``` {source} ``` to ``` {destination} ```");
             }
 
+
             return Task.CompletedTask;
+        }
+
+        private void ExecuteRecursiveCopy(Pipeline pipeline, bool isSourceFile, string source, string destination)
+        {
+            ValidateRecursiveSource(pipeline, isSourceFile, source);
+
+            if (StrictDictionaryReplace)
+                ExecuteStrictDictionaryCopy(pipeline, source, destination);
+            else
+                ExecuteDictionaryCopy(pipeline, source, destination);
+        }
+
+        private void ExecuteDictionaryCopy(Pipeline pipeline, string source, string destination)
+        {
+            string[] files = Directory.GetFiles(source, "*", SearchOption.AllDirectories);
+
+            foreach (string sourceFilePath in files)
+            {
+                var destinationFilePath = sourceFilePath.Replace(source, destination);
+                var destinationDirectoryPath = Path.GetDirectoryName(destinationFilePath) ?? string.Empty;
+                if(!Directory.Exists(destinationDirectoryPath))
+                    Directory.CreateDirectory(destinationDirectoryPath);
+                FileUtil.ReplaceFile(sourceFilePath, destinationFilePath);
+            }
+        }
+
+        private void ExecuteStrictDictionaryCopy(Pipeline pipeline, string source, string destination)
+        {
+            FileUtil.ReplaceDirectory(source, destination);
+            int i = 1;
+            var copiedFiles = Directory.EnumerateFiles(destination, "*", SearchOption.AllDirectories)
+                .Prepend("Copied Files")
+                .Aggregate((a, b) => $"{a}\r\n\r\n {i++}. {b}");
+            pipeline.Log(LogLevel.Information, $"{CopyStatement}\r\n\r\nCopied ``` {source} ``` to ``` {destination} ```", copiedFiles);
+        }
+
+        private void ValidateRecursiveSource(Pipeline pipeline, bool isSourceFile, string source)
+        {
+            if (!Directory.Exists(source) && !SourceRequired)
+                pipeline.Log(LogLevel.Information, $"{CopyStatement} Source not found and is not required, copy skipped");
+            if (!Directory.Exists(source) && SourceRequired)
+                throw new ArgumentException($"{CopyStatement} Source not found and is required");
+            if (isSourceFile)
+                throw new ArgumentException($"{CopyStatement} Expected Directory for recursive copy, Received file path: {source}");
+        }
+
+        private string ResolveSource(Pipeline pipeline)
+        {
+            try
+            {
+                return Source.Resolve(pipeline, this);
+            }
+            catch (InvalidOperationException e)
+            {
+                if (SourceRequired)
+                    throw new InvalidOperationException($"{CopyStatement} Failed to resolve source when source is required", e);
+                return string.Empty;
+            }
+        }
+
+        private bool ValidateSource(Pipeline pipeline, string source)
+        {
+            if (SourceRequired && string.IsNullOrEmpty(source))
+                throw new ArgumentException($"{CopyStatement} Required {nameof(Source)} is empty");
+
+            if (!SourceRequired && string.IsNullOrEmpty(source))
+            {
+                pipeline.Log(LogLevel.Information, $"{CopyStatement} Source not specified and is not required, copy skipped");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool IsSourceFile(string source)
+        {
+            try
+            {
+                return !File.GetAttributes(source).HasFlag(FileAttributes.Directory);
+            }
+            catch (Exception e)
+            {
+                if (SourceRequired)
+                    throw new InvalidOperationException($"{CopyStatement} Failed to check {nameof(Source)} attributes when {nameof(Source)} is required", e);
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Added a new toggle for StrictDictionaryReplace.
Default: On for same behaviour as before.

When toggled off only the files inside the directory will be replaced when they have a newer version of itself.
Self created files will remain untouched in the destination folder.

Sorry for removing everything to methods :D
