### PR TITLE
PathReference optimizations

### DIFF
--- a/Editor/Common/PathExtensions.cs
+++ b/Editor/Common/PathExtensions.cs
@@ -5,6 +5,6 @@ namespace ThunderKit.Common
 {
     public static class PathExtensions
     {
-        public static string Combine(params string[] parts) => parts.Aggregate((a, b) => Path.Combine(a, b)).Replace("\\", "/");
+        public static string Combine(params string[] parts) => Path.Combine(parts).Replace("\\", "/");
     }
 }

--- a/Editor/Core/Pipelines/Jobs/ExecutePipeline.cs
+++ b/Editor/Core/Pipelines/Jobs/ExecutePipeline.cs
@@ -14,11 +14,12 @@ namespace ThunderKit.Core.Pipelines.Jobs
             // pipeline.manifest is the correct field to use, stop checking every time.
             // pipieline.manifest is the manifest that is assigned to the pipeline containing this job via the editor
             var manifest = targetpipeline.manifest;
-            PipelineLog priorLogger = null;
+            var priorLogger = targetpipeline.Logger;
+            var priorExecutionInfo = targetpipeline.ExecutionInfo;
             try
             {
-                priorLogger = targetpipeline.Logger;
                 targetpipeline.Logger = pipeline.Logger;
+                targetpipeline.ExecutionInfo = pipeline.ExecutionInfo;
                 if (OverrideManifest && pipeline.manifest)
                 {
                     targetpipeline.manifest = pipeline.manifest;
@@ -31,6 +32,7 @@ namespace ThunderKit.Core.Pipelines.Jobs
             {
                 targetpipeline.manifest = manifest;
                 targetpipeline.Logger = priorLogger;
+                targetpipeline.ExecutionInfo = priorExecutionInfo;
             }
         }
     }

--- a/Editor/Core/Pipelines/Pipeline.cs
+++ b/Editor/Core/Pipelines/Pipeline.cs
@@ -140,6 +140,7 @@ namespace {0}
         public Manifest Manifest => Manifests?[ManifestIndex];
         [HideInInspector, NonSerialized]
         public PipelineLog Logger;
+        public Dictionary<string, object> ExecutionInfo;
 
         string ProgressTitle
         {
@@ -179,6 +180,10 @@ namespace {0}
                 {
                     Logger = PipelineLog.CreateLog(this);
                     isRoot = true;
+                }
+                if (ExecutionInfo == null)
+                {
+                    ExecutionInfo = new Dictionary<string, object>();
                 }
 
                 using (progressBar = new ProgressBar())
@@ -254,6 +259,7 @@ namespace {0}
             finally
             {
                 Logger = null;
+                ExecutionInfo = null;
                 if (!isRoot)
                     AssetDatabase.SaveAssets();
             }

--- a/Editor/Core/Utilities/Extensions.cs
+++ b/Editor/Core/Utilities/Extensions.cs
@@ -30,5 +30,17 @@ namespace ThunderKit.Core.Utilities
         {
             return (input & flag) == flag;
         }
+
+        public static bool TryGetValue<TValue>(this IDictionary<string, object> dict, string key, out TValue value)
+        {
+            if (!dict.TryGetValue(key, out var objValue))
+            {
+                value = default;
+                return false;
+            }
+
+            value = (TValue)objValue;
+            return true;
+        }
     }
 }


### PR DESCRIPTION
So, the name speaks for itself.

Previously, each call to `PathReference.ResolvePath()` would call `AssetDatabase.FindAllAssets()` which is so wasteful and I was clipping 9gb of RAM usage by the end of a pipeline execution (if I had more free space it would probably be bigger), which then quickly was collected and the Unity would drop to normal ~1gb.

I added collection to a pipeline, that can be used for temporary information, like in this case `PathReference` writes all found `PathReference`s and any later call during execution will only get it from pipline. This resulted in having barely any memory usage during pipeline execution. With all the bundle and assembly building and copying it was using ~300mb which is a massive improvement