### PR TITLE
Fix "latest" issue on packages

### DIFF
--- a/Editor/Core/Data/PackageSource.cs
+++ b/Editor/Core/Data/PackageSource.cs
@@ -193,6 +193,8 @@ namespace ThunderKit.Core.Data
             if (EditorApplication.isCompiling) return;
             var package = group[version];
 
+            version = string.Equals(version, "latest", StringComparison.Ordinal) ? package.version : version;
+
             var installSet = EnumerateDependencies(package).Where(dep => !dep.group.Installed).ToArray();
             var progress = 0.01f;
             var stepSize = 0.33f / installSet.Length;

--- a/Editor/Core/Pipelines/Jobs/Copy.cs
+++ b/Editor/Core/Pipelines/Jobs/Copy.cs
@@ -45,7 +45,7 @@ namespace ThunderKit.Core.Pipelines.Jobs
             var destination = Destination.Resolve(pipeline, this);
 
             if (EstablishDestination)
-                Directory.CreateDirectory((isSourceFile ? Path.GetDirectoryName(destination) : destination)!);
+                Directory.CreateDirectory((isSourceFile ? Path.GetDirectoryName(destination) : destination));
 
             if (Recursive)
                 ExecuteRecursiveCopy(pipeline, isSourceFile, source, destination);


### PR DESCRIPTION
When a new package is installed using the "latest" version instead of a "x.y.z" style version string, the Manifest that gets created has an invalid version string ("latest").

This is an issue that mainly affects Thunderstore packages, as later on when the jobs that create the .json file for the manifest have invalid dependencies.