### PR TITLE
Import Configuration Improvements

### DIFF
--- a/Editor/Common/ScriptingSymbolManager.cs
+++ b/Editor/Common/ScriptingSymbolManager.cs
@@ -11,8 +11,11 @@ namespace ThunderKit.Common.Configuration
             return attrs.Length > 0;
         }
 
-        internal static bool ContainsDefine(string define)
+        public static bool ContainsDefine(string define)
         {
+            define = define.ToUpperInvariant();
+            define = define.Replace("-", "_");
+
             foreach (BuildTargetGroup targetGroup in System.Enum.GetValues(typeof(BuildTargetGroup)))
             {
                 if (targetGroup == BuildTargetGroup.Unknown || IsObsolete(targetGroup))
@@ -33,6 +36,9 @@ namespace ThunderKit.Common.Configuration
         /// <param name="define"></param>
         public static void AddScriptingDefine(string define)
         {
+            define = define.ToUpperInvariant();
+            define = define.Replace("-", "_");
+
             foreach (BuildTargetGroup targetGroup in System.Enum.GetValues(typeof(BuildTargetGroup)))
             {
                 if (targetGroup == BuildTargetGroup.Unknown || IsObsolete(targetGroup))
@@ -60,6 +66,9 @@ namespace ThunderKit.Common.Configuration
         /// <param name="define"></param>
         public static void RemoveScriptingDefine(string define)
         {
+            define = define.ToUpperInvariant();
+            define = define.Replace("-", "_");
+
             foreach (BuildTargetGroup targetGroup in System.Enum.GetValues(typeof(BuildTargetGroup)))
             {
                 if (targetGroup == BuildTargetGroup.Unknown || IsObsolete(targetGroup))

--- a/Editor/Core/ComposableObject.cs
+++ b/Editor/Core/ComposableObject.cs
@@ -55,5 +55,90 @@ namespace ThunderKit.Core
             so.SetIsDifferentCacheDirty();
             so.ApplyModifiedProperties();
         }
-    }
+
+		/// <summary>
+		/// Function used to remove a sub-asset that is missing the script reference
+		/// </summary>
+		/// <param name="toDelete">The main asset that holds the sub-asset</param>
+		//https://gitlab.com/RotaryHeart-UnityShare/subassetmissingscriptdelete/-/tree/master/
+		public static void FixMissingScriptSubAssets(UnityEngine.Object toDelete)
+		{
+			//Create a new instance of the object to delete
+			ScriptableObject newInstance = CreateInstance(toDelete.GetType());
+
+			//Copy the original content to the new instance
+			EditorUtility.CopySerialized(toDelete, newInstance);
+			newInstance.name = toDelete.name;
+
+			string toDeletePath = AssetDatabase.GetAssetPath(toDelete);
+			string clonePath = toDeletePath.Replace(".asset", "CLONE.asset");
+
+			//Create the new asset on the project files
+			AssetDatabase.CreateAsset(newInstance, clonePath);
+			AssetDatabase.ImportAsset(clonePath);
+
+			//Unhide sub-assets
+			var subAssets = AssetDatabase.LoadAllAssetsAtPath(toDeletePath);
+			HideFlags[] flags = new HideFlags[subAssets.Length];
+			for (int i = 0; i < subAssets.Length; i++)
+			{
+				//Ignore the "corrupt" one
+				if (subAssets[i] == null)
+					continue;
+
+				//Store the previous hide flag
+				flags[i] = subAssets[i].hideFlags;
+				subAssets[i].hideFlags = HideFlags.None;
+				EditorUtility.SetDirty(subAssets[i]);
+			}
+
+			EditorUtility.SetDirty(toDelete);
+			AssetDatabase.SaveAssets();
+
+			//Reparent the subAssets to the new instance
+			foreach (var subAsset in AssetDatabase.LoadAllAssetRepresentationsAtPath(toDeletePath))
+			{
+				//Ignore the "corrupt" one
+				if (subAsset == null)
+					continue;
+
+				//We need to remove the parent before setting a new one
+				AssetDatabase.RemoveObjectFromAsset(subAsset);
+				AssetDatabase.AddObjectToAsset(subAsset, newInstance);
+			}
+
+			//Import both assets back to unity
+			AssetDatabase.ImportAsset(toDeletePath);
+			AssetDatabase.ImportAsset(clonePath);
+
+			//Reset sub-asset flags
+			for (int i = 0; i < subAssets.Length; i++)
+			{
+				//Ignore the "corrupt" one
+				if (subAssets[i] == null)
+					continue;
+
+				subAssets[i].hideFlags = flags[i];
+				EditorUtility.SetDirty(subAssets[i]);
+			}
+
+			EditorUtility.SetDirty(newInstance);
+			AssetDatabase.SaveAssets();
+
+			//Here's the magic. First, we need the system path of the assets
+			string globalToDeletePath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(Application.dataPath), toDeletePath);
+			string globalClonePath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(Application.dataPath), clonePath);
+
+			//We need to delete the original file (the one with the missing script asset)
+			//Rename the clone to the original file and finally
+			//Delete the meta file from the clone since it no longer exists
+
+			System.IO.File.Delete(globalToDeletePath);
+			System.IO.File.Delete(globalClonePath + ".meta");
+			System.IO.File.Move(globalClonePath, globalToDeletePath);
+
+			AssetDatabase.Refresh();
+		}
+
+	}
 }

--- a/Editor/Core/Config/ImportConfiguration.cs
+++ b/Editor/Core/Config/ImportConfiguration.cs
@@ -225,6 +225,17 @@ namespace ThunderKit.Core.Data
             {
                 foreach (var ce in ConfigurationExecutors)
                     ce.Cleanup();
+
+                PromptRestart();
+            }
+        }
+
+        private void PromptRestart()
+        {
+            EditorApplication.Beep();
+            if(EditorUtility.DisplayDialog("Import Process Complete", "The game has been imported succesfully, It is extremely recommended to Restart your project to ensure stability", "Restart Project", "Restartt Later"))
+            {
+                EditorApplication.OpenProject(Directory.GetCurrentDirectory());
             }
         }
 

--- a/Editor/Core/Config/ImportConfiguration.cs
+++ b/Editor/Core/Config/ImportConfiguration.cs
@@ -265,7 +265,7 @@ namespace ThunderKit.Core.Data
                 Debug.LogError($"Error during Import: {e}");
                 return;
             }
-            if (ConfigurationIndex > ConfigurationExecutors.Length - 1)
+            if (ConfigurationIndex >= ConfigurationExecutors.Length)
             {
                 foreach (var ce in ConfigurationExecutors)
                     ce.Cleanup();
@@ -279,7 +279,7 @@ namespace ThunderKit.Core.Data
             if(GetOrCreateSettings<ThunderKitSettings>().notifyWhenImportCompletes)
                 EditorApplication.Beep();
             
-            if(EditorUtility.DisplayDialog("Import Process Complete", "The game has been imported succesfully, It is extremely recommended to Restart your project to ensure stability", "Restart Project", "Restartt Later"))
+            if(EditorUtility.DisplayDialog("Import Process Complete", "The game has been imported successfully. It is recommended to restart your project to ensure stability", "Restart Project", "Restart Later"))
             {
                 EditorApplication.OpenProject(Directory.GetCurrentDirectory());
             }

--- a/Editor/Core/Config/ImportConfiguration.cs
+++ b/Editor/Core/Config/ImportConfiguration.cs
@@ -29,7 +29,7 @@ namespace ThunderKit.Core.Data
 
     public class ImportConfiguration : ThunderKitSetting
     {
-        public OptionalExecutor[] ConfigurationExecutors;
+        public OptionalExecutor[] ConfigurationExecutors = Array.Empty<OptionalExecutor>();
         public int ConfigurationIndex = -1;
         [SerializeField, HideInInspector] private int totalImportExtensionCount = -1;
 
@@ -43,6 +43,7 @@ namespace ThunderKit.Core.Data
             if(configInstance.CheckForNewImportConfigs(out var executors))
             {
                 var objs = LoadAllAssetRepresentationsAtPath(assetPath).ToArray();
+                configInstance.ConfigurationExecutors = Array.Empty<OptionalExecutor>();
                 foreach (var obj in objs)
                 {
                     if (obj)
@@ -125,9 +126,11 @@ namespace ThunderKit.Core.Data
 
         public override void Initialize()
         {
-            var configurationAssemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();
-            FilterForConfigurationAssemblies(configurationAssemblies);
-            LoadImportExtensions(GetOptionalExecutors(configurationAssemblies));
+            var configAssemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();
+            FilterForConfigurationAssemblies(configAssemblies);
+            var executorTypes = GetOptionalExecutors(configAssemblies);
+            totalImportExtensionCount = executorTypes.Count;
+            LoadImportExtensions(executorTypes);
             SaveAssets();
             EditorApplication.update += DoImport;
         }

--- a/Editor/Core/Config/ImportConfiguration.cs
+++ b/Editor/Core/Config/ImportConfiguration.cs
@@ -271,7 +271,7 @@ namespace ThunderKit.Core.Data
                 Debug.LogError($"Error during Import: {e}");
                 return;
             }
-            if (ConfigurationIndex > ConfigurationExecutors.Length)
+            if (ConfigurationIndex > ConfigurationExecutors.Length - 1)
             {
                 foreach (var ce in ConfigurationExecutors)
                     ce.Cleanup();
@@ -282,7 +282,9 @@ namespace ThunderKit.Core.Data
 
         private void PromptRestart()
         {
-            EditorApplication.Beep();
+            if(GetOrCreateSettings<ThunderKitSettings>().notifyWhenImportCompletes)
+                EditorApplication.Beep();
+            
             if(EditorUtility.DisplayDialog("Import Process Complete", "The game has been imported succesfully, It is extremely recommended to Restart your project to ensure stability", "Restart Project", "Restartt Later"))
             {
                 EditorApplication.OpenProject(Directory.GetCurrentDirectory());

--- a/Editor/Core/Data/ThunderKitSettings.cs
+++ b/Editor/Core/Data/ThunderKitSettings.cs
@@ -115,6 +115,7 @@ namespace ThunderKit.Core.Data
         [SerializeField]
         private bool FirstLoad = true;
         public bool ShowOnStartup = true;
+        public bool notifyWhenImportCompletes = true;
         public string GameExecutable;
         public string GamePath;
         public bool Is64Bit;

--- a/Third Party Notices.md
+++ b/Third Party Notices.md
@@ -60,3 +60,6 @@ This package contains third-party software components governed by the license(s)
 * License:  [The MIT License](https://raw.githubusercontent.com/LogosBible/bsdiff.net/master/ReadMe.txt)
 * [Local License](assetlink://GUID/a497c35352fe7154dbee71f93bc5e633)
 * BsTool is a replacement for the original project's 2 programs, BsDiff and BsPatch, providing an API instead of programs
+
+## subassetmissingscriptdelete
+* https://gitlab.com/RotaryHeart-UnityShare/subassetmissingscriptdelete/-/tree/master/

--- a/UXML/Settings/ThunderKitSettings.UXML
+++ b/UXML/Settings/ThunderKitSettings.UXML
@@ -13,6 +13,15 @@
             <ui:Label text="Game Executable" class="thunderkit-field-label"/>
             <ui:TextField name="asset-name-field" binding-path="GameExecutable" class="thunderkit-field-input"/>
         </ui:VisualElement>
+        
+        <ui:VisualElement style="flex-direction: row;">
+            <ui:VisualElement class="field-section">
+                <ui:VisualElement class="thunderkit-field">
+                    <ui:Label text="Notify when import is complete" class="thunderkit-field-label"/>
+                    <ui:Toggle name="asset-name-field" binding-path="notifyWhenImportCompletes" class="thunderkit-field-input"/>
+                </ui:VisualElement>
+            </ui:VisualElement>
+        </ui:VisualElement>
 
         <ui:VisualElement name="game-config-button-container">
             <ui:Button name="browse-button" text="Browse" class="standardbutton"/>


### PR DESCRIPTION
This PR fixes some issues the Import Configuration system had, alongside adding some new functionalities.

Fixes:
1.- Fixes a major bug regarding the ending process of the system, where the Cleanup procedure would not execute due to an error in the If statement before it

Improvements:
1.- Import Configuration now tries to update itself whenever the editor compiles via an InitializeOnLoad method, this in turn makes it possible to download an Importer extension and immediately see them on the ImportConfiguration without the need to delete the asset. This works by caching the current amount of optional executors in the app domain and then updating the asset if the count is different from the cached one.
2.- A lot of the code on Initialize has been moved to different methods in the ImportConfiguration class, this is due to the first improvement reusing a lot of the code that was found there
3.- Added a static utility method on ComposableObject that allows you to remove null sub assets while keeping the meta file intact
4.- Added a new Toggle on the ThunderKitSettings, this toggle is used to determine wether or not to notify the end user that the import process is complete using the EditorApplication.Beep() method.
5.- Most importantly, i've added a Restart prompt at the end of the import configuration, i've noticed that just after importing some unusual bugs occur (such as creating any custom monobehaviour cant be added to game objects), but these bugs disappear as soon as the editor is restarted.

I would've liked to make it so when the import process notifies the end user with the beep, to also force focus of the unity editor application to make sure they see the restart prompt, i couldnt find a way to do this however.