### PR TITLE
allow compilation of assemblies in debug mode

### DIFF
--- a/Editor/Core/Pipelines/Jobs/StageAssemblies.cs
+++ b/Editor/Core/Pipelines/Jobs/StageAssemblies.cs
@@ -76,10 +76,10 @@ namespace ThunderKit.Core.Pipelines.Jobs
 #pragma warning restore CS0649 
 
         public bool stageDebugDatabases;
+        public bool releaseBuild;
         [PathReferenceResolver, Tooltip("Location where built assemblies will be cached before being staged")]
         public string assemblyArtifactPath = "<AssemblyStaging>";
         public BuildTarget buildTarget = BuildTarget.StandaloneWindows;
-        public BuildTargetGroup buildTargetGroup = BuildTargetGroup.Standalone;
 
 
         public sealed override async Task Execute(Pipeline pipeline)
@@ -148,8 +148,9 @@ namespace ThunderKit.Core.Pipelines.Jobs
             {
                 additionalReferences = definition.asm.allReferences,
             };
+            builder.flags = releaseBuild ? AssemblyBuilderFlags.None : AssemblyBuilderFlags.DevelopmentBuild;
             builder.excludeReferences = builder.defaultReferences.Where(rf => rf.Contains(assemblyName)).ToArray();
-            builder.buildTargetGroup = buildTargetGroup;
+            builder.buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
             builder.buildTarget = buildTarget;
             builder.buildFinished += OnBuildFinished;
             builder.buildStarted += OnBuildStarted;

--- a/Editor/Core/Pipelines/Jobs/StageAssemblies.cs
+++ b/Editor/Core/Pipelines/Jobs/StageAssemblies.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -76,7 +76,7 @@ namespace ThunderKit.Core.Pipelines.Jobs
 #pragma warning restore CS0649 
 
         public bool stageDebugDatabases;
-        public bool releaseBuild;
+        public bool releaseBuild = true;
         [PathReferenceResolver, Tooltip("Location where built assemblies will be cached before being staged")]
         public string assemblyArtifactPath = "<AssemblyStaging>";
         public BuildTarget buildTarget = BuildTarget.StandaloneWindows;


### PR DESCRIPTION
As the title says, this just adds a check that allows you to specify if the StageAssemblies job should compile the assemblies in Debug or Release mode, this in turn allows the proper usage of the ``#if DEBUG`` scripting define clauses