### PR TITLE
Version check improvements

### DIFF
--- a/Editor/Core/Config/ImportConfiguration.cs
+++ b/Editor/Core/Config/ImportConfiguration.cs
@@ -361,7 +361,5 @@ namespace ThunderKit.Core.Data
                         $"\r\n\t Make sure you're using the same version of the Unity Editor as the Unity Player for the game.");
             return versionMatch;
         }
-
-
     }
 }


### PR DESCRIPTION
Fixes an issue where version checking could fail for data files not supported by the current (outdated) AssetsTools implementation
Additionally fixes an issue were version checks would fail to match correctly when they should.