### PR TITLE
ImportConfiguration fixes. Initialize settings only when not importing assets.

### DIFF
--- a/Editor/Core/ComposableObject.cs
+++ b/Editor/Core/ComposableObject.cs
@@ -52,6 +52,8 @@ namespace ThunderKit.Core
             for (int x = index; x < dataArray.arraySize; x++)
                 dataArray.MoveArrayElement(x + 1, x);
 
+			dataArray.arraySize--;
+
             so.SetIsDifferentCacheDirty();
             so.ApplyModifiedProperties();
         }

--- a/Editor/Core/ComposableObject.cs
+++ b/Editor/Core/ComposableObject.cs
@@ -33,30 +33,25 @@ namespace ThunderKit.Core
             stepField.serializedObject.ApplyModifiedProperties();
         }
 
-        public void RemoveElement(ComposableElement instance, int index)
-        {
-            var so = new SerializedObject(this);
-            var dataArray = so.FindProperty(nameof(Data));
-            var elementAtIndex = dataArray.GetArrayElementAtIndex(index).objectReferenceValue as ComposableElement;
-            if (elementAtIndex != instance)
-            {
-                Debug.LogError("ComposableObject.RemoveElement: instance does not match index");
-                return;
-            }
-            AssetDatabase.RemoveObjectFromAsset(instance);
+		public void RemoveElement(ComposableElement instance, int index)
+		{
+			var so = new SerializedObject(this);
+			var dataArray = so.FindProperty(nameof(Data));
+			var elementAtIndex = dataArray.GetArrayElementAtIndex(index).objectReferenceValue as ComposableElement;
+			if (elementAtIndex != instance)
+			{
+				Debug.LogError("ComposableObject.RemoveElement: instance does not match index");
+				return;
+			}
+			AssetDatabase.RemoveObjectFromAsset(instance);
 
-            dataArray.DeleteArrayElementAtIndex(index);
+			DeleteElementAtIndex(dataArray, index);
 
-            DestroyImmediate(instance);
+			DestroyImmediate(instance);
 
-            for (int x = index; x < dataArray.arraySize; x++)
-                dataArray.MoveArrayElement(x + 1, x);
-
-			dataArray.arraySize--;
-
-            so.SetIsDifferentCacheDirty();
-            so.ApplyModifiedProperties();
-        }
+			so.SetIsDifferentCacheDirty();
+			so.ApplyModifiedProperties();
+		}
 
 		/// <summary>
 		/// Function used to remove a sub-asset that is missing the script reference
@@ -142,5 +137,12 @@ namespace ThunderKit.Core
 			AssetDatabase.Refresh();
 		}
 
+		private void DeleteElementAtIndex(SerializedProperty array, int index)
+		{
+			var elementToDelete = array.GetArrayElementAtIndex(index);
+			if (elementToDelete.propertyType == SerializedPropertyType.ObjectReference)
+				elementToDelete.objectReferenceValue = null;
+			array.DeleteArrayElementAtIndex(index);
+		}
 	}
 }

--- a/Editor/Core/Config/ImportConfiguration.cs
+++ b/Editor/Core/Config/ImportConfiguration.cs
@@ -312,6 +312,10 @@ namespace ThunderKit.Core.Data
                 AssetDatabase.SaveAssets();
                 PromptRestart();
             }
+            else
+            {
+                EditorApplication.update += StepImporters;
+            }
         }
 
         private void PromptRestart()

--- a/Editor/Core/Config/ImportConfiguration.cs
+++ b/Editor/Core/Config/ImportConfiguration.cs
@@ -64,14 +64,14 @@ namespace ThunderKit.Core.Data
 
             EditorApplication.update -= StepImporters;
 
-            var settings = GetOrCreateSettings<ImportConfiguration>();
-            var assetPath = GetAssetPath(settings);
+            var configInstance = GetOrCreateSettings<ImportConfiguration>();
+            var assetPath = GetAssetPath(configInstance);
             var guid = AssetPathToGUID(assetPath);
-            if (settings.CheckForNewImportConfigs(out var executors))
+            if (configInstance.CheckForNewImportConfigs(out var executors))
             {
                 var executorStates = new Dictionary<Type, bool>();
                 var objs = LoadAllAssetRepresentationsAtPath(assetPath).ToArray();
-                settings.ConfigurationExecutors = Array.Empty<OptionalExecutor>();
+                configInstance.ConfigurationExecutors = Array.Empty<OptionalExecutor>();
                 foreach (var obj in objs)
                 {
                     if (obj)
@@ -84,18 +84,18 @@ namespace ThunderKit.Core.Data
                         DestroyImmediate(obj, true);
                     }
                 }
-                ComposableObject.FixMissingScriptSubAssets(settings);
-                settings = LoadAssetAtPath<ImportConfiguration>(GUIDToAssetPath(guid));
-                settings.LoadImportExtensions(executors, executorStates);
+                ComposableObject.FixMissingScriptSubAssets(configInstance);
+                configInstance = LoadAssetAtPath<ImportConfiguration>(GUIDToAssetPath(guid));
+                configInstance.LoadImportExtensions(executors, executorStates);
                 SaveAssets();
             }
 
-            settings.ConfigurationExecutors = LoadAllAssetRepresentationsAtPath(assetPath)
+            configInstance.ConfigurationExecutors = LoadAllAssetRepresentationsAtPath(assetPath)
                 .OfType<OptionalExecutor>()
                 .OrderByDescending(executor => executor.Priority)
                 .ToArray();
 
-            settings.ImportGame();
+            configInstance.ImportGame();
         }
 
         public override void CreateSettingsUI(VisualElement rootElement)

--- a/Editor/Core/Data/ThunderKitSetting.cs
+++ b/Editor/Core/Data/ThunderKitSetting.cs
@@ -26,10 +26,23 @@ namespace ThunderKit.Core.Data
 
         private Editor editor;
         [InitializeOnLoadMethod]
-        static void Ensure()
+        static void EnsureSubscriptions()
         {
             SettingsWindow.OnSettingsLoading -= Ensure;
             SettingsWindow.OnSettingsLoading += Ensure;
+
+            EditorApplication.update -= Ensure;
+            EditorApplication.update += Ensure;
+        }
+
+        private static void Ensure()
+        {
+            if (EditorApplication.isCompiling || EditorApplication.isUpdating)
+            {
+                return;
+            }
+
+            EditorApplication.update -= Ensure;
 
             if (thunderKitSettingsTypes == null)
                 try

--- a/Editor/Core/Data/ThunderKitSettings.cs
+++ b/Editor/Core/Data/ThunderKitSettings.cs
@@ -40,22 +40,7 @@ namespace ThunderKit.Core.Data
             CompilationPipeline.assemblyCompilationFinished -= CopyAssemblyCSharp;
             CompilationPipeline.assemblyCompilationFinished += CopyAssemblyCSharp;
 
-            var settings = GetOrCreateSettings<ThunderKitSettings>();
-            if (settings.FirstLoad && settings.ShowOnStartup)
-                EditorApplication.update += ShowSettings;
-
-            settings.QuickAccessPipelines = AssetDatabase.FindAssets($"t:{nameof(Pipeline)}", Constants.FindAllFolders)
-                .Select(guid => AssetDatabase.GUIDToAssetPath(guid))
-                .Select(path => AssetDatabase.LoadAssetAtPath<Pipeline>(path))
-                .Where(pipeline => pipeline)
-                .Where(pipeline => pipeline.QuickAccess)
-                .ToArray();
-            settings.QuickAccessManifests = AssetDatabase.FindAssets($"t:{nameof(Manifest)}", Constants.FindAllFolders)
-                .Select(guid => AssetDatabase.GUIDToAssetPath(guid))
-                .Select(path => AssetDatabase.LoadAssetAtPath<Manifest>(path))
-                .Where(manifest => manifest)
-                .Where(manifest => manifest.QuickAccess)
-                .ToArray();
+            EditorApplication.update += InitSettings;
         }
         private static void EditorApplicationQuitting() => CopyAssemblyCSharp(null, null);
         private static bool EditorApplication_wantsToQuit()
@@ -76,11 +61,36 @@ namespace ThunderKit.Core.Data
                 FileUtil.ReplaceFile(file, outputPath);
             }
         }
-        private static void ShowSettings()
+        private static void InitSettings()
         {
-            EditorApplication.update -= ShowSettings;
-            SettingsWindow.ShowSettings();
+            if (EditorApplication.isCompiling || EditorApplication.isUpdating)
+            {
+                return;
+            }
+
+            EditorApplication.update -= InitSettings;
+
             var settings = GetOrCreateSettings<ThunderKitSettings>();
+            settings.QuickAccessPipelines = AssetDatabase.FindAssets($"t:{nameof(Pipeline)}", Constants.FindAllFolders)
+                .Select(guid => AssetDatabase.GUIDToAssetPath(guid))
+                .Select(path => AssetDatabase.LoadAssetAtPath<Pipeline>(path))
+                .Where(pipeline => pipeline)
+                .Where(pipeline => pipeline.QuickAccess)
+                .ToArray();
+            settings.QuickAccessManifests = AssetDatabase.FindAssets($"t:{nameof(Manifest)}", Constants.FindAllFolders)
+                .Select(guid => AssetDatabase.GUIDToAssetPath(guid))
+                .Select(path => AssetDatabase.LoadAssetAtPath<Manifest>(path))
+                .Where(manifest => manifest)
+                .Where(manifest => manifest.QuickAccess)
+                .ToArray();
+
+            if (!settings.FirstLoad || !settings.ShowOnStartup)
+            {
+                settings.FirstLoad = false;
+                return;
+            }
+
+            SettingsWindow.ShowSettings();
             settings.FirstLoad = false;
             EditorUtility.SetDirty(settings);
             AssetDatabase.SaveAssets();

--- a/Editor/Core/Inspectors/ManifestEditor.cs
+++ b/Editor/Core/Inspectors/ManifestEditor.cs
@@ -38,6 +38,7 @@ namespace ThunderKit.Core.Inspectors
             if (EditorGUI.EndChangeCheck())
             {
                 settings.SetQuickAccess(manifest, manifest.QuickAccess);
+                EditorUtility.SetDirty(manifest);
                 serializedObject.ApplyModifiedProperties();
             }
         }

--- a/Editor/Core/Inspectors/PipelineEditor.cs
+++ b/Editor/Core/Inspectors/PipelineEditor.cs
@@ -43,6 +43,7 @@ namespace ThunderKit.Core.Inspectors
             if (EditorGUI.EndChangeCheck())
             {
                 settings.SetQuickAccess(pipeline, pipeline.QuickAccess);
+                EditorUtility.SetDirty(pipeline);
                 serializedObject.ApplyModifiedProperties();
             }
 

--- a/Editor/Core/Pipelines/PipelineToolbar.cs
+++ b/Editor/Core/Pipelines/PipelineToolbar.cs
@@ -75,7 +75,6 @@ namespace ThunderKit.Core.Pipelines
         {
             manifestIcon = AssetDatabase.LoadAssetAtPath<Texture2D>(Constants.Icons.ManifestIconPath);
             pipelineIcon = AssetDatabase.LoadAssetAtPath<Texture2D>(Constants.Icons.PipelineIconPath);
-            settings = ThunderKitSetting.GetOrCreateSettings<ThunderKitSettings>();
 
             ToolbarExtender.RightToolbarGUI.Add(OnToolbarGUI);
 
@@ -107,6 +106,11 @@ namespace ThunderKit.Core.Pipelines
 
         static void OnToolbarGUI()
         {
+            if (settings == null)
+            {
+                settings = ThunderKitSetting.GetOrCreateSettings<ThunderKitSettings>();
+            }
+
             GUISkin origSkin = GUI.skin;
             if (popupStyle == null)
             {

--- a/Editor/Thunderstore/ThunderstoreSource.cs
+++ b/Editor/Thunderstore/ThunderstoreSource.cs
@@ -22,6 +22,11 @@ namespace ThunderKit.Integrations.Thunderstore
         static void CreateThunderKitExtensionSource() => EditorApplication.update += EnsureThunderKitExtensions;
         private static void EnsureThunderKitExtensions()
         {
+            if (EditorApplication.isCompiling || EditorApplication.isUpdating)
+            {
+                return;
+            }
+            
             EditorApplication.update -= EnsureThunderKitExtensions;
 
             var basePath = $"{SettingsPath}/ThunderKit Extensions.asset";


### PR DESCRIPTION
During execution of a method with `InitializeOnLoadMethod` attribute if settings asset is being reimported because it was changed `LoadAssetAtPath` will return null for that asset. Which means calling `ThunderKitSetting.GetOrCreateSettings` during that time would potentially return a new instance overwriting the old one. So we delay settings initialization until AssetDatabase is done with importing.

`ImportConfiguraton` wasn't storing the `ConfigurationIndex` change after the last importer, as the result of it the last importer was re-run on each domain reload. Also, made so that `StepImporters` is unsubscribed from `EditorApplication.update` on each step and re-subscribed on domain reload or if there is another importer to process. Which reduce unnecessary work for the editor.