### PR TITLE
Manifest files with .meta

### DIFF
--- a/Documentation/ThunderKitDocumentation/Manual/Manifest/ManifestDatums/Files.md
+++ b/Documentation/ThunderKitDocumentation/Manual/Manifest/ManifestDatums/Files.md
@@ -11,6 +11,8 @@
 The [Files](assetlink://GUID/4b243ff405b33b94dbf5b6775dd9aa33) ManifestDatum stores references to assets inside your unity project.
 
 ## Fields
+* **Include Meta Files**
+  - Include .meta files for the specified assets
 * **Files**
   - An array of assets
 

--- a/Documentation/ThunderKitDocumentation/Manual/Pipeline/PipelineJobs/StageManifestFiles.md
+++ b/Documentation/ThunderKitDocumentation/Manual/Pipeline/PipelineJobs/StageManifestFiles.md
@@ -18,4 +18,4 @@
 
 This pipeline will copy all assets from each Files ManifestDatum attached to Manifests being processed by the current pipeline.
 
-This can be used to copy any files in that are assets under the Assets folder of hte project out to locations specified in the Files ManifestDatum's Staging Paths.
+This can be used to copy any files in that are assets under the Assets folder of the project out to locations specified in the Files ManifestDatum's Staging Paths.

--- a/Editor/Core/Manifests/Datum/Files.cs
+++ b/Editor/Core/Manifests/Datum/Files.cs
@@ -4,6 +4,7 @@ namespace ThunderKit.Core.Manifests.Datum
 {
     public class Files : ManifestDatum
     {
+        public bool includeMetaFiles;
         public Object[] files;
     }
 }

--- a/Editor/Core/Pipelines/Jobs/StageManifestFiles.cs
+++ b/Editor/Core/Pipelines/Jobs/StageManifestFiles.cs
@@ -40,6 +40,17 @@ namespace ThunderKit.Core.Pipelines.Jobs
                                 .Aggregate((a, b) => $"{a}\r\n\r\n {i++}. {b}");
                             pipeline.Log(LogLevel.Information, $"staged ``` {sourcePath} ``` in ``` {destPath} ```", copiedFiles);
                         }
+
+                        if (files.includeMetaFiles)
+                        {
+                            var metaSourcePath = sourcePath + ".meta";
+                            if (File.Exists(metaSourcePath))
+                            {
+                                var metaDestPath = Path.Combine(outputPath, Path.GetFileName(metaSourcePath)).Replace("\\", "/");
+                                FileUtil.ReplaceFile(metaSourcePath, metaDestPath);
+                                pipeline.Log(LogLevel.Information, $"staged ``` {metaSourcePath} ``` in ``` {metaDestPath} ```");
+                            }
+                        }
                     }
 
             return Task.CompletedTask;


### PR DESCRIPTION
There are cases where you would want to include .meta files. One such case is RoR2EditorKit release pipeline which builds a Thunderstore package for ThunderKit, which should include .meta files