### PR TITLE
Search for other assembly files

### DIFF
--- a/Editor/Core/Data/ThunderKitSettings.cs
+++ b/Editor/Core/Data/ThunderKitSettings.cs
@@ -68,7 +68,7 @@ namespace ThunderKit.Core.Data
         }
         private static void CopyAssemblyCSharp(string somevalue, CompilerMessage[] message)
         {
-            foreach (var file in Directory.GetFiles("Packages", "Assembly-CSharp.dll", SearchOption.AllDirectories))
+            foreach (var file in Directory.GetFiles("Packages", "Assembly-CSharp*.dll", SearchOption.AllDirectories))
             {
                 var fileName = Path.GetFileName(file);
                 var outputPath = Combine("Library", "ScriptAssemblies", fileName);


### PR DESCRIPTION
Previously thunderkit wouldn't copy files like Assembly-Csharp-firstpass.dll. This has been tested for subnautica, which has that firstpass file that should also be imported, but it hasn't been tested for other games. I believe it should be fine, but I don't know how other games may be structured.