### PR TITLE
Update FixMisreferencedAssets.cs

### DIFF
--- a/Editor/Core/Migration/FixMisreferencedAssets.cs
+++ b/Editor/Core/Migration/FixMisreferencedAssets.cs
@@ -17,7 +17,7 @@ namespace ThunderKit.Migration
             try
             {
                 AssetDatabase.StartAssetEditing();
-                var scriptRefRegex = new Regex("  m_Script: \\{fileID: (\\d*?), guid: (\\w*?), type: \\d\\}");
+                var scriptRefRegex = new Regex("  m_Script: \\{fileID: (-?\\d*?), guid: (\\w*?), type: \\d\\}");
                 var monoScripts = AssetDatabase.FindAssets("t:MonoScript")
                     .Select(AssetDatabase.GUIDToAssetPath)
                     .Select(AssetDatabase.LoadAssetAtPath<MonoScript>)
@@ -43,7 +43,6 @@ namespace ThunderKit.Migration
                         monoScriptTable[fileId] = guid;
                 }
 
-                var paths = Selection.assetGUIDs.Select(guid => AssetDatabase.GUIDToAssetPath(guid));
                 foreach (var file in selection.Select(AssetDatabase.GUIDToAssetPath).Select(path => (path, lines: File.ReadLines(path))))
                 {
                     var lines = file.lines.ToArray();

--- a/Editor/Core/Migration/FixMisreferencedAssets.cs
+++ b/Editor/Core/Migration/FixMisreferencedAssets.cs
@@ -13,10 +13,9 @@ namespace ThunderKit.Migration
         [MenuItem("Tools/ThunderKit/Migration/Switch DLL references to CS references")]
         public static void Execute()
         {
-            var selection = Selection.objects;
+            var selection = Selection.assetGUIDs;
             try
             {
-
                 AssetDatabase.StartAssetEditing();
                 var scriptRefRegex = new Regex("  m_Script: \\{fileID: (\\d*?), guid: (\\w*?), type: \\d\\}");
                 var monoScripts = AssetDatabase.FindAssets("t:MonoScript")
@@ -44,7 +43,8 @@ namespace ThunderKit.Migration
                         monoScriptTable[fileId] = guid;
                 }
 
-                foreach (var file in selection.Select(AssetDatabase.GetAssetPath).Select(path => (path, lines: File.ReadLines(path))))
+                var paths = Selection.assetGUIDs.Select(guid => AssetDatabase.GUIDToAssetPath(guid));
+                foreach (var file in selection.Select(AssetDatabase.GUIDToAssetPath).Select(path => (path, lines: File.ReadLines(path))))
                 {
                     var lines = file.lines.ToArray();
                     var changes = false;
@@ -66,7 +66,6 @@ namespace ThunderKit.Migration
                         Debug.Log($"Changed {file.path}");
                         File.WriteAllLines(file.path, lines);
                     }
-
                 }
             }
             finally
@@ -74,7 +73,7 @@ namespace ThunderKit.Migration
                 AssetDatabase.StopAssetEditing();
                 AssetDatabase.Refresh();
                 Selection.objects = null;
-                Selection.objects = selection;
+                Selection.objects = selection.Select(AssetDatabase.GUIDToAssetPath).Select(AssetDatabase.LoadMainAssetAtPath).ToArray();
             }
         }
     }


### PR DESCRIPTION
Asset Reference Migration did not seem to work when an asset could not load as an object. This seemed to cause problems when attempting to get the asset path of an object that hasn't been able to load. Switched the system to use asset GUID's instead of Objects for getting asset paths.

Attempting to fix asset with missing Mono Script before change:
![Before](https://github.com/PassivePicasso/ThunderKit/assets/70601472/ca36157e-a980-4d87-a0cf-d9af92e5cb6a)

Attempt to fix asset after change:
![After](https://github.com/PassivePicasso/ThunderKit/assets/70601472/1f0b5148-4456-4cbd-a1cb-0c9ec98ec992)

Also fixes an issue where the RegEx search for fileID's would not account for negative ID's, resulting in them being unconverted.