### PR TITLE
Sanitize modified strings to not have control characters

### DIFF
--- a/Editor/Core/Attributes/PathReferenceResolverAttribute.cs
+++ b/Editor/Core/Attributes/PathReferenceResolverAttribute.cs
@@ -1,9 +1,8 @@
-﻿using System;
+﻿using UnityEngine;
 
 namespace ThunderKit.Core.Attributes
 {
-    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
-    public class PathReferenceResolverAttribute : Attribute
+    public class PathReferenceResolverAttribute : PropertyAttribute
     {
     }
 }

--- a/Editor/Core/Controls/PathReferenceResolverDrawer.cs
+++ b/Editor/Core/Controls/PathReferenceResolverDrawer.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using ThunderKit.Core.Attributes;
+using UnityEditor;
+using UnityEngine;
+using static Markdig.Helpers.StringLineGroup;
+
+namespace ThunderKit.Core
+{
+
+    [CustomPropertyDrawer(typeof(PathReferenceResolverAttribute))]
+    public class PathReferenceResolverDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginChangeCheck();
+
+            EditorGUI.PropertyField(position, property, label);
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                if (property.propertyType == SerializedPropertyType.String)
+                {
+                    property.stringValue = new string(property.stringValue.Where(x => !char.IsControl(x)).ToArray());
+                }
+                else if (property.isArray && property.arrayElementType == "string")
+                {
+                    for (int i = 0; i < property.arraySize; i++)
+                    {
+                        SerializedProperty prop = property.GetArrayElementAtIndex(i);
+                        prop.stringValue = new string(prop.stringValue.Where(x => !char.IsControl(x)).ToArray());
+                    }
+                }
+
+                property.serializedObject.ApplyModifiedProperties();
+                property.serializedObject.UpdateIfRequiredOrScript();
+            }
+        }
+    }
+}

--- a/Editor/Core/Controls/PathReferenceResolverDrawer.cs.meta
+++ b/Editor/Core/Controls/PathReferenceResolverDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bba2a98a2ff26c940b120604477d1a76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Core/Data/PackageGroup.cs
+++ b/Editor/Core/Data/PackageGroup.cs
@@ -73,8 +73,7 @@ namespace ThunderKit.Core.Data
 
         public string InstalledVersion => PackageManifest.version;
 
-        public bool Installed => PackageManifest.name?.Equals(PackageHelper.GetCleanPackageName(DependencyId), StringComparison.OrdinalIgnoreCase) ?? false;
-
+        public bool Installed => PackageManifest.name != null;
 
         public override bool Equals(object obj)
         {

--- a/Editor/Core/Inspectors/ComposableElementEditor.cs
+++ b/Editor/Core/Inspectors/ComposableElementEditor.cs
@@ -1,11 +1,9 @@
-﻿using ThunderKit.Core;
-using ThunderKit.Core.Utilities;
-using UnityEditor;
+﻿using UnityEditor;
 
 namespace ThunderKit.Core.Inspectors
 {
     [CustomEditor(typeof(ComposableElement), true)]
-    public class ComposableElementEditor : UnityEditor.Editor
+    public class ComposableElementEditor : Editor
     {
         public override void OnInspectorGUI()
         {

--- a/Editor/Core/Inspectors/ComposableElementEditor.cs
+++ b/Editor/Core/Inspectors/ComposableElementEditor.cs
@@ -1,4 +1,5 @@
 ﻿using ThunderKit.Core;
+using ThunderKit.Core.Utilities;
 using UnityEditor;
 
 namespace ThunderKit.Core.Inspectors
@@ -10,7 +11,7 @@ namespace ThunderKit.Core.Inspectors
         {
             try
             {
-                DrawPropertiesExcluding(serializedObject, new string[] { "m_Script" });
+                EditorHelpers.DrawSanitizedPropertiesExcluding(serializedObject, new string[] { "m_Script" });
             }
             catch { }
         }

--- a/Editor/Core/Inspectors/ComposableElementEditor.cs
+++ b/Editor/Core/Inspectors/ComposableElementEditor.cs
@@ -1,6 +1,4 @@
-﻿using ThunderKit.Core;
-using ThunderKit.Core.Utilities;
-using UnityEditor;
+﻿using UnityEditor;
 
 namespace ThunderKit.Core.Inspectors
 {
@@ -11,7 +9,7 @@ namespace ThunderKit.Core.Inspectors
         {
             try
             {
-                EditorHelpers.DrawSanitizedPropertiesExcluding(serializedObject, new string[] { "m_Script" });
+                DrawPropertiesExcluding(serializedObject, new string[] { "m_Script" });
             }
             catch { }
         }

--- a/Editor/Core/Inspectors/ComposableElementEditor.cs
+++ b/Editor/Core/Inspectors/ComposableElementEditor.cs
@@ -11,7 +11,7 @@ namespace ThunderKit.Core.Inspectors
         {
             try
             {
-                EditorHelpers.DrawSanitizedPropertiesExcluding(serializedObject, new string[] { "m_Script" });
+                DrawPropertiesExcluding(serializedObject, new string[] { "m_Script" });
             }
             catch { }
         }

--- a/Editor/Core/Inspectors/ComposableObjectEditor.cs
+++ b/Editor/Core/Inspectors/ComposableObjectEditor.cs
@@ -62,7 +62,7 @@ namespace ThunderKit.Core.Inspectors
             //Ensure SerializedObject is up to date with latest data
             serializedObject.Update();
             var excludedProperties = ExcludedProperties().Append("m_Script").Append("Data").ToArray();
-            DrawPropertiesExcluding(serializedObject, excludedProperties);
+            EditorHelpers.DrawSanitizedPropertiesExcluding(serializedObject, excludedProperties);
             GUILayout.Space(4);
 
             dataArray = serializedObject.FindProperty(nameof(ComposableObject.Data));

--- a/Editor/Core/Inspectors/ComposableObjectEditor.cs
+++ b/Editor/Core/Inspectors/ComposableObjectEditor.cs
@@ -62,7 +62,7 @@ namespace ThunderKit.Core.Inspectors
             //Ensure SerializedObject is up to date with latest data
             serializedObject.Update();
             var excludedProperties = ExcludedProperties().Append("m_Script").Append("Data").ToArray();
-            EditorHelpers.DrawSanitizedPropertiesExcluding(serializedObject, excludedProperties);
+            DrawPropertiesExcluding(serializedObject, excludedProperties);
             GUILayout.Space(4);
 
             dataArray = serializedObject.FindProperty(nameof(ComposableObject.Data));

--- a/Editor/Core/Inspectors/ComposableObjectEditor.cs
+++ b/Editor/Core/Inspectors/ComposableObjectEditor.cs
@@ -1,22 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
+using ThunderKit.Common;
 using ThunderKit.Core.Attributes;
-using ThunderKit.Core.Windows;
 using ThunderKit.Core.Manifests.Datum;
+using ThunderKit.Core.Utilities;
+using ThunderKit.Core.Windows;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Profiling;
 using static UnityEditor.EditorGUIUtility;
 using Debug = UnityEngine.Debug;
-using ThunderKit.Common;
-using UnityEngine.Profiling;
-using ThunderKit.Core.Utilities;
 
 namespace ThunderKit.Core.Inspectors
 {
     [CustomEditor(typeof(ComposableObject), true)]
-    public class ComposableObjectEditor : UnityEditor.Editor
+    public class ComposableObjectEditor : Editor
     {
         const string MissingScriptReference = "Missing Script Reference";
         protected static GUISkin EditorSkin;
@@ -29,7 +28,7 @@ namespace ThunderKit.Core.Inspectors
         }
 
         static ComposableElement ClipboardItem;
-        Dictionary<UnityEngine.Object, UnityEditor.Editor> Editors;
+        Dictionary<UnityEngine.Object, Editor> Editors;
         SerializedProperty dataArray;
 
         protected virtual IEnumerable<string> ExcludedProperties()
@@ -43,7 +42,7 @@ namespace ThunderKit.Core.Inspectors
             try
             {
                 var targetObject = target as ComposableObject;
-                Editors = new Dictionary<UnityEngine.Object, UnityEditor.Editor>();
+                Editors = new Dictionary<UnityEngine.Object, Editor>();
             }
             catch
             {
@@ -370,7 +369,7 @@ namespace ThunderKit.Core.Inspectors
 
                         return true;
                     }
-                    catch(Exception e)
+                    catch (Exception e)
                     {
                         Debug.LogError(e);
                         return false;

--- a/Editor/Core/Utilities/EditorHelpers.cs
+++ b/Editor/Core/Utilities/EditorHelpers.cs
@@ -33,34 +33,5 @@ namespace ThunderKit.Core.Utilities
                 property.serializedObject.ApplyModifiedProperties();
             }
         }
-        public static void DrawSanitizedPropertiesExcluding(SerializedObject obj,  params string[] propertyToExclude)
-        {
-            SerializedProperty iterator = obj.GetIterator();
-            bool enterChildren = true;
-            while (iterator.NextVisible(enterChildren))
-            {
-                enterChildren = false;
-                if (!propertyToExclude.Contains(iterator.name))
-                {
-                    EditorGUI.BeginChangeCheck();
-                    EditorGUILayout.PropertyField(iterator, true);
-                    if (EditorGUI.EndChangeCheck())
-                    {
-                        if (iterator.propertyType == SerializedPropertyType.String)
-                        {
-                            iterator.stringValue = new string(iterator.stringValue.Where(x => !char.IsControl(x)).ToArray());
-                        }
-                        else if (iterator.isArray && iterator.arrayElementType == "string")
-                        {
-                            for (int i = 0; i < iterator.arraySize; i++)
-                            {
-                                SerializedProperty prop = iterator.GetArrayElementAtIndex(i);
-                                prop.stringValue = new string(prop.stringValue.Where(x => !char.IsControl(x)).ToArray());
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
This workaround a bug in unity 2018.4.12f1 on Linux where pressing ctrl + any letter will cause data corruption since it writes ASCII control characters.