### PR TITLE
Add checks for catching errors while importing project settings.

### DIFF
--- a/Editor/Core/Config/Common/ImportProjectSettings.cs
+++ b/Editor/Core/Config/Common/ImportProjectSettings.cs
@@ -41,6 +41,7 @@ namespace ThunderKit.Core.Config.Common
         public override int Priority => Constants.Priority.ProjectSettingsImport;
         public override string Description => "Import ProjectSettings from games with globalgamemanagers";
         public long IncludedSettings;
+        public bool LogImportErrors;
         private AssetsManager assetsManager;
         private YAMLExportManager exportManager;
         private PPtrExporterInfo pptrExporterInfo;
@@ -114,7 +115,6 @@ namespace ThunderKit.Core.Config.Common
         {
             foreach (var info in globalGameManagersFile.file.AssetInfos)
             {
-                Debug.Log($"Getting asset info from {globalGameManagersFile.path} ... {info.PathId} ({info.TypeId})");
                 var type = (AssetClassID)info.TypeId;
                 if (ignoreTypesOnExport.Contains(type))
                 {
@@ -132,9 +132,10 @@ namespace ThunderKit.Core.Config.Common
                     var collection = new ProjectSettingCollection { Assets = { assetExternal } };
                     SaveCollection(collection, null, Path.Combine(outputProjectSettingsDirectory, $"{fileName}.{collection.ExportExtension}"), unityVersion);
                 }
-                catch (OutOfMemoryException doom)
+                catch (Exception exception)
                 {
-                    Debug.LogError(doom);
+                    if (LogImportErrors)
+                        Debug.LogError($"Caught an error when trying to import external asset from path ID {info.PathId} of the game managers file: {exception}");
                 }
 
             }

--- a/Editor/Core/Config/Common/ImportProjectSettings.cs
+++ b/Editor/Core/Config/Common/ImportProjectSettings.cs
@@ -114,6 +114,7 @@ namespace ThunderKit.Core.Config.Common
         {
             foreach (var info in globalGameManagersFile.file.AssetInfos)
             {
+                Debug.Log($"Getting asset info from {globalGameManagersFile.path} ... {info.PathId} ({info.TypeId})");
                 var type = (AssetClassID)info.TypeId;
                 if (ignoreTypesOnExport.Contains(type))
                 {
@@ -125,9 +126,17 @@ namespace ThunderKit.Core.Config.Common
                     fileName = Enum.GetName(typeof(AssetClassID), info.TypeId);
                 }
 
-                AssetExternal assetExternal = assetsManager.GetExtAsset(globalGameManagersFile, 0, info.PathId);
-                var collection = new ProjectSettingCollection { Assets = { assetExternal } };
-                SaveCollection(collection, null, Path.Combine(outputProjectSettingsDirectory, $"{fileName}.{collection.ExportExtension}"), unityVersion);
+                try
+                {
+                    AssetExternal assetExternal = assetsManager.GetExtAsset(globalGameManagersFile, 0, info.PathId);
+                    var collection = new ProjectSettingCollection { Assets = { assetExternal } };
+                    SaveCollection(collection, null, Path.Combine(outputProjectSettingsDirectory, $"{fileName}.{collection.ExportExtension}"), unityVersion);
+                }
+                catch (OutOfMemoryException doom)
+                {
+                    Debug.LogError(doom);
+                }
+
             }
         }
 

--- a/UXML/Settings/ImportProjectSettings.UXML
+++ b/UXML/Settings/ImportProjectSettings.UXML
@@ -1,13 +1,10 @@
-<ui:UXML xmlns:ui="UnityEngine.Experimental.UIElements" xmlns:uie="UnityEditor.Experimental.UIElements" editor-extension-mode="True">
-
-        <ui:VisualElement class="thunderkit-field">
-            <ui:Label text="Included Settings" class="thunderkit-field-label"
-                      tooltip="Project Settings to import if available in the game files"
-            />
-            <uie:MaskField name="included-settings-field" binding-path="IncludedSettings" choices="AudioManager, ClusterInputManager, DynamicsManager, EditorBuildSettings, EditorSettings, GraphicsSettings, InputManager, NavMeshAreas, NetworkManager, Physics2DSettings, PresetManager, ProjectSettings, QualitySettings, TagManager, TimeManager, UnityConnectSettings, VFXManager, XRSettings " class="thunderkit-field-input"
-                           tooltip="Project Settings to import if available in the game files"
-            />
-        </ui:VisualElement>
-
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" editor-extension-mode="True">
+    <ui:VisualElement class="thunderkit-field">
+        <ui:Label text="Included Settings" tooltip="Project Settings to import if available in the game files" class="thunderkit-field-label" />
+        <uie:MaskField name="included-settings-field" binding-path="IncludedSettings" choices="AudioManager, ClusterInputManager, DynamicsManager, EditorBuildSettings, EditorSettings, GraphicsSettings, InputManager, NavMeshAreas, NetworkManager, Physics2DSettings, PresetManager, ProjectSettings, QualitySettings, TagManager, TimeManager, UnityConnectSettings, VFXManager, XRSettings " tooltip="Project Settings to import if available in the game files" class="thunderkit-field-input" />
+    </ui:VisualElement>
+    <ui:VisualElement class="thunderkit-field" style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); flex-direction: row;">
+        <ui:Label tabindex="-1" text="Log Settings Import Errors" display-tooltip-when-elided="true" class="thunderkit-field-label" style="flex-grow: 0; flex-direction: row;" />
+        <ui:Toggle value="false" binding-path="LogImportErrors" class="thunderkit-field-input" />
+    </ui:VisualElement>
 </ui:UXML>
-


### PR DESCRIPTION
When using ThunderKit for setting up unity to mod Kerbal Space Program 2, we consistently run into an out of memory error while trying to import project settings, something necessary for us to do things like rendering drag cubes for the game. After doing some investigating, I found that ignoring the assets in the game managers file that cause this error (via a try catch) and logging them fixed these issues for us, as such this PR adds that to the ImportProjectSettings file, and adds an option into the ThunderKit settings that enables or disables logging any errors found while importing the project settings.