### PR TITLE
Fix Documentation fold arrows

### DIFF
--- a/Editor/Core/Windows/Documentation.cs
+++ b/Editor/Core/Windows/Documentation.cs
@@ -385,6 +385,7 @@ namespace ThunderKit.Core.Windows
                 var header = new VisualElement();
                 header.AddToClassList("header");
                 ArrowIcon = new VisualElement();
+                ArrowIcon.name = "arrow-icon";
 
                 header.Add(ArrowIcon);
                 ArrowIcon.AddToClassList("in-foldout");

--- a/USS/documentation.uss
+++ b/USS/documentation.uss
@@ -47,31 +47,36 @@ PageEntry>#page-entry-children
 {
     flex-direction: column;
 }
+
 Chapter>.header,
 PageEntry>.header
 {
-    padding-left: 14px;
     flex-direction: row;
+    align-items: center;
+}
+
+#arrow-icon
+{
+    align-self: center;
+    width: 16px;
+    height: 15px;
+    -unity-slice-top: 15;
+    -unity-slice-left: 16;
 }
 Chapter>.header>.in-foldout,
 PageEntry>.header>.in-foldout 
 {
-    position: absolute;
-    align-self: center;
-    width: 16px;
-    height: 15px;
 	background-image: resource("Builtin Skins/LightSkin/Images/IN foldout.png");
-    -unity-slice-top: 15;
-    -unity-slice-left: 16;
 }
 Chapter>.header>.in-foldout-on,
 PageEntry>.header>.in-foldout-on 
 {
-    position: absolute;
-    align-self: center;
-    width: 14px;
-    height: 12px;
 	background-image: resource("Builtin Skins/LightSkin/Images/IN foldout on.png");
+}
+
+Chapter>.header>Label
+{
+    flex-grow: 1;
 }
 Chapter>.header>Label:hover,
 PageEntry>.header>Label:hover


### PR DESCRIPTION
Changed Documentation USS to display arrow, as it was overlapping with the text.

Now:
<img width="282" height="166" alt="image" src="https://github.com/user-attachments/assets/12e2c3b4-bf56-40a3-bbc8-898d460fcb47" />

Prior:
<img width="259" height="174" alt="image" src="https://github.com/user-attachments/assets/3ec3a46b-00da-4dce-892e-0fcf51714c33" />

