### PR TITLE
Update SelfDestructingActionAsset to work on unity 6.5 beta

### DIFF
--- a/Editor/Addressable/Tools/Controls/TransformHierarchyTreeView.cs
+++ b/Editor/Addressable/Tools/Controls/TransformHierarchyTreeView.cs
@@ -11,8 +11,11 @@ namespace ThunderKit.Addressable.Tools
     {
         private readonly Transform root;
         private readonly TreeViewItem localRootItem;
+        #if UNITY_6000_5_OR_NEWER
+        private readonly Dictionary<EntityId, Transform> transformLookup = new Dictionary<EntityId, Transform>();
+        #else
         private readonly Dictionary<int, Transform> transformLookup = new Dictionary<int, Transform>();
-
+        #endif
         public TransformHierarchyTreeView(TreeViewState state, Transform root) : base(state)
         {
             this.root = root;
@@ -22,8 +25,23 @@ namespace ThunderKit.Addressable.Tools
         {
             int depth = 0;
             transformLookup.Clear();
-            transformLookup[root.GetInstanceID()] = root;
-            var firstItem = new TreeViewItem { id = root.GetInstanceID(), depth = depth++, displayName = root.name, children = new List<TreeViewItem>() };
+            transformLookup[
+                #if UNITY_6000_5_OR_NEWER
+                root.GetEntityId()
+                #else
+                root.GetInstanceID()
+                #endif
+            ] = root;
+            var firstItem = new TreeViewItem {
+                #if UNITY_6000_5_OR_NEWER
+                id = root.GetEntityId(),
+                #else
+                id = root.GetInstanceID(),
+                #endif
+                depth = depth++,
+                displayName = root.name,
+                children = new List<TreeViewItem>() 
+            };
             localRootItem.children.Add(firstItem);
 
             ConstructTree(depth, firstItem, root);
@@ -39,7 +57,11 @@ namespace ThunderKit.Addressable.Tools
                 transformLookup[child.GetInstanceID()] = child;
                 var childItem = new TreeViewItem
                 {
+                    #if UNITY_6000_5_OR_NEWER
+                    id = child.GetEntityId(),
+                    #else
                     id = child.GetInstanceID(),
+                    #endif
                     depth = depth,
                     parent = parentItem,
                     displayName = child.name

--- a/Editor/Addressable/Tools/Controls/TransformHierarchyTreeView.cs
+++ b/Editor/Addressable/Tools/Controls/TransformHierarchyTreeView.cs
@@ -5,23 +5,33 @@ using UnityEditor.Graphs;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 
+#if UNITY_6000_5_OR_NEWER
+using TreeViewT = TreeView<EntityId>;
+using TreeViewStateT = TreeViewState<EntityId>;
+using TreeViewItemT = TreeViewItem<EntityId>;
+#else
+using TreeViewT = TreeView;
+using TreeViewStateT = TreeViewState;
+using TreeViewItemT = TreeViewItem;
+#endif
+
 namespace ThunderKit.Addressable.Tools
 {
-    public class TransformHierarchyTreeView : TreeView
+    public class TransformHierarchyTreeView : TreeViewT
     {
         private readonly Transform root;
-        private readonly TreeViewItem localRootItem;
+        private readonly TreeViewItem<EntityId> localRootItem;
         #if UNITY_6000_5_OR_NEWER
         private readonly Dictionary<EntityId, Transform> transformLookup = new Dictionary<EntityId, Transform>();
         #else
         private readonly Dictionary<int, Transform> transformLookup = new Dictionary<int, Transform>();
         #endif
-        public TransformHierarchyTreeView(TreeViewState state, Transform root) : base(state)
+        public TransformHierarchyTreeView(TreeViewStateT state, Transform root) : base(state)
         {
             this.root = root;
-            localRootItem = new TreeViewItem { id = 0, depth = -1, displayName = "root", children = new List<TreeViewItem>() };
+            localRootItem = new TreeViewItemT { id = default, depth = -1, displayName = "root", children = new List<TreeViewItem>() };
         }
-        protected override TreeViewItem BuildRoot()
+        protected override TreeViewItemT BuildRoot()
         {
             int depth = 0;
             transformLookup.Clear();
@@ -32,7 +42,7 @@ namespace ThunderKit.Addressable.Tools
                 root.GetInstanceID()
                 #endif
             ] = root;
-            var firstItem = new TreeViewItem {
+            var firstItem = new TreeViewItemT {
                 #if UNITY_6000_5_OR_NEWER
                 id = root.GetEntityId(),
                 #else
@@ -40,7 +50,7 @@ namespace ThunderKit.Addressable.Tools
                 #endif
                 depth = depth++,
                 displayName = root.name,
-                children = new List<TreeViewItem>() 
+                children = new List<TreeViewItemT>() 
             };
             localRootItem.children.Add(firstItem);
 
@@ -49,13 +59,13 @@ namespace ThunderKit.Addressable.Tools
             return localRootItem;
         }
 
-        private void ConstructTree(int depth, TreeViewItem parentItem, Transform parent)
+        private void ConstructTree(int depth, TreeViewItemT parentItem, Transform parent)
         {
             if (parentItem.children == null) parentItem.children = new List<TreeViewItem>();
             foreach (Transform child in parent)
             {
                 transformLookup[child.GetInstanceID()] = child;
-                var childItem = new TreeViewItem
+                var childItem = new TreeViewItemT
                 {
                     #if UNITY_6000_5_OR_NEWER
                     id = child.GetEntityId(),
@@ -70,13 +80,26 @@ namespace ThunderKit.Addressable.Tools
                 parentItem.children.Add(childItem);
             }
         }
-        protected override void SingleClickedItem(int id)
+        
+        protected override void SingleClickedItem(
+            #if UNITY_6000_5_OR_LATER
+            EntityId id
+            #else
+            int id
+            #endif
+        )
         {
             base.SingleClickedItem(id);
             Selection.activeGameObject = transformLookup[id].gameObject;
         }
 
-        protected override void DoubleClickedItem(int id)
+        protected override void DoubleClickedItem(
+            #if UNITY_6000_5_OR_LATER
+            EntityId id
+            #else
+            int id
+            #endif
+        )
         {
             base.DoubleClickedItem(id);
             Selection.activeGameObject = transformLookup[id].gameObject;

--- a/Editor/Addressable/Tools/Controls/TransformHierarchyTreeView.cs
+++ b/Editor/Addressable/Tools/Controls/TransformHierarchyTreeView.cs
@@ -20,7 +20,7 @@ namespace ThunderKit.Addressable.Tools
     public class TransformHierarchyTreeView : TreeViewT
     {
         private readonly Transform root;
-        private readonly TreeViewItem<EntityId> localRootItem;
+        private readonly TreeViewItemT localRootItem;
         #if UNITY_6000_5_OR_NEWER
         private readonly Dictionary<EntityId, Transform> transformLookup = new Dictionary<EntityId, Transform>();
         #else
@@ -29,7 +29,7 @@ namespace ThunderKit.Addressable.Tools
         public TransformHierarchyTreeView(TreeViewStateT state, Transform root) : base(state)
         {
             this.root = root;
-            localRootItem = new TreeViewItemT { id = default, depth = -1, displayName = "root", children = new List<TreeViewItem>() };
+            localRootItem = new TreeViewItemT { id = default, depth = -1, displayName = "root", children = new List<TreeViewItemT>() };
         }
         protected override TreeViewItemT BuildRoot()
         {
@@ -61,10 +61,16 @@ namespace ThunderKit.Addressable.Tools
 
         private void ConstructTree(int depth, TreeViewItemT parentItem, Transform parent)
         {
-            if (parentItem.children == null) parentItem.children = new List<TreeViewItem>();
+            if (parentItem.children == null) parentItem.children = new List<TreeViewItemT>();
             foreach (Transform child in parent)
             {
-                transformLookup[child.GetInstanceID()] = child;
+                transformLookup[
+                    #if UNITY_6005_OR_NEWER
+                    child.GetEntityId()
+                    #else
+                    child.GetInstanceID()
+                    #endif
+                ] = child;
                 var childItem = new TreeViewItemT
                 {
                     #if UNITY_6000_5_OR_NEWER

--- a/Editor/Addressable/Tools/Controls/TransformHierarchyTreeView.cs
+++ b/Editor/Addressable/Tools/Controls/TransformHierarchyTreeView.cs
@@ -82,7 +82,7 @@ namespace ThunderKit.Addressable.Tools
         }
         
         protected override void SingleClickedItem(
-            #if UNITY_6000_5_OR_LATER
+            #if UNITY_6000_5_OR_NEWER
             EntityId id
             #else
             int id
@@ -94,7 +94,7 @@ namespace ThunderKit.Addressable.Tools
         }
 
         protected override void DoubleClickedItem(
-            #if UNITY_6000_5_OR_LATER
+            #if UNITY_6000_5_OR_NEWER
             EntityId id
             #else
             int id

--- a/Editor/Addressable/Tools/Controls/TransformHierarchyTreeView.cs
+++ b/Editor/Addressable/Tools/Controls/TransformHierarchyTreeView.cs
@@ -6,13 +6,13 @@ using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 
 #if UNITY_6000_5_OR_NEWER
-using TreeViewT = TreeView<EntityId>;
-using TreeViewStateT = TreeViewState<EntityId>;
-using TreeViewItemT = TreeViewItem<EntityId>;
+using TreeViewT = UnityEditor.IMGUI.Controls.TreeView<UnityEngine.EntityId>;
+using TreeViewStateT = UnityEditor.IMGUI.Controls.TreeViewState<UnityEngine.EntityId>;
+using TreeViewItemT = UnityEditor.IMGUI.Controls.TreeViewItem<UnityEngine.EntityId>;
 #else
-using TreeViewT = TreeView;
-using TreeViewStateT = TreeViewState;
-using TreeViewItemT = TreeViewItem;
+using TreeViewT = UnityEditor.IMGUI.Controls.TreeView;
+using TreeViewStateT = UnityEditor.IMGUI.Controls.TreeViewState;
+using TreeViewItemT = UnityEditor.IMGUI.Controls.TreeViewItem;
 #endif
 
 namespace ThunderKit.Addressable.Tools

--- a/Editor/Addressable/Tools/Controls/TransformHierarchyTreeView.cs
+++ b/Editor/Addressable/Tools/Controls/TransformHierarchyTreeView.cs
@@ -65,7 +65,7 @@ namespace ThunderKit.Addressable.Tools
             foreach (Transform child in parent)
             {
                 transformLookup[
-                    #if UNITY_6005_OR_NEWER
+                    #if UNITY_6000_5_OR_NEWER
                     child.GetEntityId()
                     #else
                     child.GetInstanceID()

--- a/Editor/Core/Actions/SelfDestructingActionAsset.cs
+++ b/Editor/Core/Actions/SelfDestructingActionAsset.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEditor.ProjectWindowCallback;
+using UnityEngine;
 
 namespace ThunderKit.Core.Actions
 {

--- a/Editor/Core/Actions/SelfDestructingActionAsset.cs
+++ b/Editor/Core/Actions/SelfDestructingActionAsset.cs
@@ -3,7 +3,19 @@ using UnityEditor.ProjectWindowCallback;
 
 namespace ThunderKit.Core.Actions
 {
-    public class SelfDestructingActionAsset : EndNameEditAction
+    #if UNITY_6000_5_OR_NEWER
+    class SelfDestructingActionAsset : AssetCreationEndAction
+    {
+        public Action<EntityId, string, string> action;
+
+        public override void Action(EntityId instanceId, string pathName, string resourceFile)
+        {
+            action(instanceId, pathName, resourceFile);
+            CleanUp();
+        }
+    }
+    #else
+    class SelfDestructingActionAsset : EndNameEditAction
     {
         public Action<int, string, string> action;
 
@@ -13,4 +25,5 @@ namespace ThunderKit.Core.Actions
             CleanUp();
         }
     }
+    #endif
 }

--- a/Editor/Core/Documentation/DocumentationHelpers.cs
+++ b/Editor/Core/Documentation/DocumentationHelpers.cs
@@ -27,8 +27,18 @@ namespace ThunderKit.Core.Documentation
 
             AssetDatabase.Refresh();
 
+            #if UNITY_6000_5_OR_NEWER
+            Action<EntityId, string, string> action =
+            #else
             Action<int, string, string> action =
-                (int instanceId, string markPath, string resourceFile) =>
+            #endif
+                (
+                    #if UNITY_6000_5_OR_NEWER
+                    EntityId instanceId,
+                    #else
+                    int instanceId,
+                    #endif
+                    string markPath, string resourceFile) =>
                 {
                     var name = Path.GetFileNameWithoutExtension(markPath);
                     var rootPath = Path.GetDirectoryName(markPath);
@@ -47,7 +57,7 @@ namespace ThunderKit.Core.Documentation
             var findTexture = typeof(EditorGUIUtility).GetMethod(nameof(EditorGUIUtility.FindTexture), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
             findTextureParams[0] = typeof(DefaultAsset);
             var icon = (Texture2D)findTexture.Invoke(null, findTextureParams);
-            ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0, endAction, assetPathAndName, icon, null);
+            ProjectWindowUtil.StartNameEditingIfProjectWindowExists(default, endAction, assetPathAndName, icon, null);
         }
     }
 }

--- a/Editor/Core/Utilities/ScriptableHelper.cs
+++ b/Editor/Core/Utilities/ScriptableHelper.cs
@@ -62,7 +62,7 @@ namespace ThunderKit.Core.Utilities
             var icon = (Texture2D)findTexture.Invoke(null, findTextureParams);
             ProjectWindowUtil.StartNameEditingIfProjectWindowExists(
                 #if UNITY_6000_5_OR_NEWER
-                asset.GetEntityID(),
+                asset.GetEntityId(),
                 #else
                 asset.GetInstanceID(),
                 #endif

--- a/Editor/Core/Utilities/ScriptableHelper.cs
+++ b/Editor/Core/Utilities/ScriptableHelper.cs
@@ -33,8 +33,20 @@ namespace ThunderKit.Core.Utilities
             }
             var name = typeof(T).Name;
             string assetPathAndName = AssetDatabase.GenerateUniqueAssetPath($"{path}/{name}.asset");
+            #if UNITY_6000_5_OR_NEWER
+            Action<EntityId, string, string> action =
+            #else
             Action<int, string, string> action =
-                (int instanceId, string pathname, string resourceFile) =>
+            #endif
+                (
+                    #if UNITY_6000_5_OR_NEWER
+                    EntityId instanceId,
+                    #else
+                    int instanceId,
+                    #endif
+                    string pathname, 
+                    string resourceFile
+                ) =>
                   {
                       AssetDatabase.CreateAsset(asset, pathname);
                       AssetDatabase.SaveAssets();
@@ -48,7 +60,13 @@ namespace ThunderKit.Core.Utilities
             var findTexture = typeof(EditorGUIUtility).GetMethod(nameof(EditorGUIUtility.FindTexture), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
             findTextureParams[0] = typeof(T);
             var icon = (Texture2D)findTexture.Invoke(null, findTextureParams);
-            ProjectWindowUtil.StartNameEditingIfProjectWindowExists(asset.GetInstanceID(), endAction, assetPathAndName, icon, null);
+            ProjectWindowUtil.StartNameEditingIfProjectWindowExists(
+                #if UNITY_6000_5_OR_NEWER
+                asset.GetEntityID(),
+                #else
+                asset.GetInstanceID(),
+                #endif
+                endAction, assetPathAndName, icon, null);
         }
 
         /// <summary>

--- a/Editor/Core/Windows/PipelineLogWindow.cs
+++ b/Editor/Core/Windows/PipelineLogWindow.cs
@@ -72,7 +72,7 @@ namespace ThunderKit.Core.Windows
 
         [OnOpenAsset]
         #if UNITY_6000_5_OR_NEWER
-        public static bool OnOpen(EnityId entityId, int line)
+        public static bool OnOpen(EntityId entityId, int line)
         #else
         public static bool OnOpen(int instanceId, int line)
         #endif

--- a/Editor/Core/Windows/PipelineLogWindow.cs
+++ b/Editor/Core/Windows/PipelineLogWindow.cs
@@ -71,9 +71,17 @@ namespace ThunderKit.Core.Windows
 
 
         [OnOpenAsset]
+        #if UNITY_6000_5_OR_NEWER
+        public static bool OnOpen(EnityId entityId, int line)
+        #else
         public static bool OnOpen(int instanceId, int line)
+        #endif
         {
+            #if UNITY_6000_5_OR_NEWER
+            var asset = EditorUtility.EntityIdToObject(entityId);
+            #else
             var asset = EditorUtility.InstanceIDToObject(instanceId);
+            #endif
             if (asset is PipelineLog log)
             {
                 ShowLog(log);

--- a/Editor/Core/Windows/TemplatedWindow.cs
+++ b/Editor/Core/Windows/TemplatedWindow.cs
@@ -67,9 +67,21 @@ namespace ThunderKit.Core.Windows
                 path = path.Replace(Path.GetFileName(AssetDatabase.GetAssetPath(Selection.activeObject)), "");
             }
             string assetPathAndName = AssetDatabase.GenerateUniqueAssetPath($"NewTemplatedWindow.cs");
-
+            
+            #if UNITY_6000_5_OR_NEWER
+            Action<EntityId, string, string> action =
+            #else
             Action<int, string, string> action =
-                (int instanceId, string pathname, string resourceFile) =>
+            #endif
+                (
+                    #if UNITY_6000_5_OR_NEWER
+                    EntityId instanceId,
+                    #else
+                    int instanceId,
+                    #endif
+                    string pathname, 
+                    string resourceFile
+                ) =>
                 {
                     var name = Path.GetFileNameWithoutExtension(pathname);
                     var title = ObjectNames.NicifyVariableName(name);
@@ -86,7 +98,7 @@ namespace ThunderKit.Core.Windows
             var findTexture = typeof(EditorGUIUtility).GetMethod(nameof(EditorGUIUtility.FindTexture), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
             findTextureParams[0] = typeof(MonoScript);
             var icon = (Texture2D)findTexture.Invoke(null, findTextureParams);
-            ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0, endAction, assetPathAndName, icon, null);
+            ProjectWindowUtil.StartNameEditingIfProjectWindowExists(default, endAction, assetPathAndName, icon, null);
         }
 
         static string GetScriptTemplate(string name, string title, string rootElementName) =>

--- a/Editor/Markdown/MarkdownStatic.cs
+++ b/Editor/Markdown/MarkdownStatic.cs
@@ -9,6 +9,18 @@ namespace ThunderKit.Markdown
     public static class MarkdownStatic
     {
         readonly static object[] findTextureParams = new object[1];
+        #if UNITY_6000_5_OR_LATER
+        class SelfDestructingActionAsset : AssetCreationEndAction
+        {
+            public Action<EntityId, string, string> action;
+
+            public override void Action(EntityId instanceId, string pathName, string resourceFile)
+            {
+                action(instanceId, pathName, resourceFile);
+                CleanUp();
+            }
+        }
+        #else
         class SelfDestructingActionAsset : EndNameEditAction
         {
             public Action<int, string, string> action;
@@ -19,6 +31,7 @@ namespace ThunderKit.Markdown
                 CleanUp();
             }
         }
+        #endif
 
         [MenuItem("Assets/Create/Markdown File")]
         public static void Create()
@@ -37,7 +50,15 @@ namespace ThunderKit.Markdown
             AssetDatabase.Refresh();
 
             Action<int, string, string> action =
-                (int instanceId, string pathname, string resourceFile) =>
+                (
+                    #if UNITY_6000_5_OR_LATER
+                    EntityId instanceId,
+                    #else
+                    int instanceId,
+                    #endif
+                    string pathname, 
+                    string resourceFile
+                ) =>
                 {
                     File.WriteAllText(pathname, "# Markdown File");
                     AssetDatabase.Refresh();

--- a/Editor/Markdown/MarkdownStatic.cs
+++ b/Editor/Markdown/MarkdownStatic.cs
@@ -78,7 +78,7 @@ namespace ThunderKit.Markdown
             var findTexture = typeof(EditorGUIUtility).GetMethod(nameof(EditorGUIUtility.FindTexture), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
             findTextureParams[0] = typeof(TextAsset);
             var icon = (Texture2D)findTexture.Invoke(null, findTextureParams);
-            ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0, endAction, assetPathAndName, icon, null);
+            ProjectWindowUtil.StartNameEditingIfProjectWindowExists(default, endAction, assetPathAndName, icon, null);
         }
     }
 }

--- a/Editor/Markdown/MarkdownStatic.cs
+++ b/Editor/Markdown/MarkdownStatic.cs
@@ -9,7 +9,7 @@ namespace ThunderKit.Markdown
     public static class MarkdownStatic
     {
         readonly static object[] findTextureParams = new object[1];
-        #if UNITY_6000_5_OR_LATER
+        #if UNITY_6000_5_OR_NEWER
         class SelfDestructingActionAsset : AssetCreationEndAction
         {
             public Action<EntityId, string, string> action;
@@ -51,7 +51,7 @@ namespace ThunderKit.Markdown
 
             Action<int, string, string> action =
                 (
-                    #if UNITY_6000_5_OR_LATER
+                    #if UNITY_6000_5_OR_NEWER
                     EntityId instanceId,
                     #else
                     int instanceId,

--- a/Editor/Markdown/MarkdownStatic.cs
+++ b/Editor/Markdown/MarkdownStatic.cs
@@ -49,7 +49,11 @@ namespace ThunderKit.Markdown
 
             AssetDatabase.Refresh();
 
+            #if UNITY_6000_5_OR_NEWER
+            Action<EntityId, string, string> action =
+            #else
             Action<int, string, string> action =
+            #endif
                 (
                     #if UNITY_6000_5_OR_NEWER
                     EntityId instanceId,


### PR DESCRIPTION
So, Unity 6.5 removed the instance id stuff and replaced it with entity id and it breaks quite a few parts of Thunderkit, specifically in the UI sections, this replaces all instances of instanceid with entityid conditionally for unity 6000.5 or later, it also swaps out TreeView to TreeView<EntityId> with the same conditions