### PR TITLE
update ImportProjectSettings to use Game Version instead of Editor Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 9.4.2
+
+### Fixes
+
+* `ImportProjectSettings` now resolves class data against the Unity version that
+  built the game read from `globalgamemanagers` metadata — rather than the
+  running Editor version, so a mismatched Editor patch release no longer corrupts
+  version-sensitive settings such as `PlayerSettings`
+  it should be noted that using mismatched editor and game versions is still unsupported and resolving a mismatch is the first step in trying to fix problems. Mismatched imports can reuslt in data loss for PlayerSettings.
+
 ## 9.4.1
 
 ### New Features

--- a/Editor/Core/Config/Common/ImportProjectSettings.cs
+++ b/Editor/Core/Config/Common/ImportProjectSettings.cs
@@ -106,24 +106,13 @@ namespace ThunderKit.Core.Config.Common
         }
 
 
-        // Raised when the class data (tpk) cannot be used to interpret the game data at
-        // all: an unparseable Unity version or a tpk that lists no type versions. The
-        // production import treats this as "skip ProjectSettings import" rather than a
-        // hard failure; tests use it to distinguish a total failure from the expected
-        // per-setting skips handled inside ExportGlobalGameManagers.
+        // Unrecoverable class-data failure (unparseable version or empty tpk); the import skips rather than failing hard.
         internal class UnsupportedClassDataException : Exception
         {
             public UnsupportedClassDataException(string message) : base(message) { }
         }
 
-        // Core of the import: resolve a class database from the tpk for the running Unity
-        // version, load the game's globalgamemanagers, and export each contained setting
-        // to a YAML .asset under outputDirectory. Returns the paths actually written.
-        //
-        // Decoupled from ThunderKitSettings/AssetDatabase so it can be exercised directly
-        // against committed fixtures (see ImportProjectSettingsTests). Throws
-        // UnsupportedClassDataException for the two unrecoverable cases; individual
-        // settings whose type data is missing are skipped (logged) rather than thrown.
+        // Internal seam decoupled from ThunderKitSettings/AssetDatabase so tests can drive it against committed fixtures (see ImportProjectSettingsTests).
         internal List<string> ExportProjectSettings(string classDataPath, string globalGameManagersPath, string outputDirectory, string unityVersion)
         {
             outputProjectSettingsDirectory = outputDirectory;
@@ -140,12 +129,21 @@ namespace ThunderKit.Core.Config.Common
             assetsManager = new AssetsManager();
             assetsManager.LoadClassPackage(classDataPath);
 
+            // Prefer the version that built the game, recorded in globalgamemanagers, over the Editor's.
+            var globalGameManagersFile = assetsManager.LoadAssetsFile(globalGameManagersPath, true);
+            var fileVersion = globalGameManagersFile.file.Metadata.UnityVersion;
+            if (!string.IsNullOrEmpty(fileVersion) && ClassDataManager.TryParseUnityVersion(fileVersion, out _, out _, out _))
+            {
+                if (fileVersion != unityVersion)
+                    Debug.LogWarning($"[ThunderKit] Game was built with Unity {fileVersion}, but the Editor is {unityVersion}. " +
+                        "Mismatched Editor and game versions are unsupported and can cause data loss for settings such as PlayerSettings.");
+                unityVersion = fileVersion;
+            }
+
             if (!ClassDataManager.TryParseUnityVersion(unityVersion, out var major, out var minor, out var patch))
                 throw new UnsupportedClassDataException($"could not parse Unity version '{unityVersion}'.");
 
-            // The tpk rarely lists every Unity version. Discover the versions it does
-            // contain and load the class database for the closest one (newest at or
-            // before the running version) rather than requiring an exact match.
+            // The tpk rarely lists every Unity version, so resolve the closest one at or before the game's version.
             var availableVersions = assetsManager.ClassPackage?.TpkTypeTree?.Versions;
             var resolvedVersion = ClassDataManager.SelectBestVersion(availableVersions, major, minor, patch);
             if (resolvedVersion == null)
@@ -160,8 +158,6 @@ namespace ThunderKit.Core.Config.Common
 
             assetsManager.LoadClassDatabaseFromPackage(resolvedVersion);
             exportManager = YAMLExportManager.CreateDefault();
-
-            var globalGameManagersFile = assetsManager.LoadAssetsFile(globalGameManagersPath, true);
 
             return ExportGlobalGameManagers(globalGameManagersFile, new UnityVersion(unityVersion));
         }
@@ -182,10 +178,7 @@ namespace ThunderKit.Core.Config.Common
                     fileName = Enum.GetName(typeof(AssetClassID), info.TypeId);
                 }
 
-                // A given setting type may be absent from the class data when the tpk
-                // does not fully cover the running Unity version (see ClassDataManager).
-                // Treat that as a per-setting warning rather than aborting the whole
-                // import so the remaining settings still come through.
+                // A setting's type may be missing from the class data, so skip it per-setting rather than aborting the whole import.
                 try
                 {
                     AssetExternal assetExternal = assetsManager.GetExtAsset(globalGameManagersFile, 0, info.PathId);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.passivepicasso.thunderkit",
-  "version": "9.4.1",
+  "version": "9.4.2",
   "displayName": "ThunderKit",
   "description": "Unity Game Mod Development extension with build, packaging and analysis tools",
   "unity": "2018.4",


### PR DESCRIPTION
This prevents exceptions being throwing by assets tools, but not does not mean that the settings import correctly for the project version in the editor.

As such during import a warning will be thrown.  This is a backup step for users who decide to turn off the Unity Version check and use mismatched versions, reminding them that they could have a sub-optimal environment.