### PR TITLE
Add Unity 6 compatibility to Addressable tools

### DIFF
--- a/Editor/Addressable/Tools/AddressableBrowser.cs
+++ b/Editor/Addressable/Tools/AddressableBrowser.cs
@@ -197,8 +197,13 @@ namespace ThunderKit.Addressable.Tools
 
             ((ArrayList)directory.itemsSource).Sort(comparer);
 
+#if UNITY_2021_2_OR_NEWER
+            directory.Rebuild();
+            directoryContent.Rebuild();
+#else
             directory.Refresh();
             directoryContent.Refresh();
+#endif
         }
         ResoourceNameSorter comparer = new ResoourceNameSorter();
         private class ResoourceNameSorter : IComparer
@@ -218,7 +223,11 @@ namespace ThunderKit.Addressable.Tools
 
             directoryContent.itemsSource.Clear();
             Filter(directoryContent.itemsSource, locations, false);
+#if UNITY_2021_2_OR_NEWER
+            directoryContent.Rebuild();
+#else
             directoryContent.Refresh();
+#endif
         }
         private string GroupLocation(IResourceLocation g)
         {

--- a/Editor/Addressable/Tools/Controls/AddressablePreviewImage.cs
+++ b/Editor/Addressable/Tools/Controls/AddressablePreviewImage.cs
@@ -17,7 +17,12 @@ using UnityEngine.Experimental.UIElements;
 
 namespace ThunderKit.Addressable.Tools
 {
+#if UNITY_6000_3_OR_NEWER
+    [UxmlElement]
+    public partial class AddressablePreviewImage : Image
+#else
     public class AddressablePreviewImage : Image
+#endif
     {
         private const string Library = "Library";
         private const string SimplyAddress = "SimplyAddress";
@@ -29,8 +34,10 @@ namespace ThunderKit.Addressable.Tools
 
         private Texture2D texture;
 
+#if !UNITY_6000_3_OR_NEWER
         public new class UxmlFactory : UxmlFactory<AddressablePreviewImage, UxmlTraits> { }
         public new class UxmlTraits : Image.UxmlTraits { }
+#endif
 
         static AddressablePreviewImage()
         {


### PR DESCRIPTION
Updates the Addressable Browser for newer Unity versions:
- Migrates AddressablePreviewImage to the Unity 6 UxmlElement API for Unity 6.3+
- Uses ListView.Rebuild() on Unity 2021.2+